### PR TITLE
Add the shortcut 'Tweak Tool' to the Arc Menu

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -1095,6 +1095,10 @@ const ApplicationsButton = new Lang.Class({
             this.rightBox.add(settings.actor, { expand: false,
                                                  x_fill: true, y_fill: false,
                                                  y_align: St.Align.START });
+            let tweaktool = new ShortcutMenuItem(this, _("Tweak Tool"), "gnome-tweak-tool-symbolic", "gnome-tweak-tool");
+            this.rightBox.add(tweaktool.actor, { expand: false,
+                                                 x_fill: true, y_fill: false,
+                                                 y_align: St.Align.START });
             let activities = new ActivitiesMenuItem(this);
             this.rightBox.add(activities.actor, { expand: false,
                                                  x_fill: true, y_fill: false,


### PR DESCRIPTION
As discussed in the issue https://github.com/LinxGem33/Arc-Menu/issues/20, this pull-request adds a _gnome-tweak-tool_ shortcut to the Arc Menu.