### PR TITLE
Add a shortcut for opening the trash folder

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -952,6 +952,10 @@ const ApplicationsButton = new Lang.Class({
             let placeMenuItem = new PlaceMenuItem(this, placeInfo);
             this.rightBox.add_actor(placeMenuItem.actor);
         }
+        
+        let placeInfo = new PlaceInfo(Gio.File.new_for_uri("trash:///"), _("Trash"));
+        let placeMenuItem = new PlaceMenuItem(this, placeInfo);
+        this.rightBox.add_actor(placeMenuItem.actor);
     },
 
     // Scroll to a specific button (menu item) in the applications scroll view


### PR DESCRIPTION
As discussed in the issue https://github.com/LinxGem33/Arc-Menu/issues/22, this pull-request adds a _Trash_ shortcut to the Arc Menu.