### PR TITLE
Add a basic Makefile for installing/uninstalling the extension from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+JS=*.js
+CSS=*.css
+MD=*.md
+JSON=*.json
+TXT=AUTHORS COPYING
+IMG=*.svg
+DIRS=schemas locale
+
+DEST=~/.local/share/gnome-shell/extensions/arc-menu@linxgem33.com
+
+
+install:
+	mkdir -p $(DEST)
+	cp $(JS) $(CSS) $(JSON) $(MD) $(TXT) $(IMG) $(DEST)
+	cp -r $(DIRS) $(DEST)
+	
+uninstall:
+	rm -rfi $(DEST)


### PR DESCRIPTION
Installing the extension from source becomes tedious after a while. To avoid that in the future for other contributors, a Makefile for installing and uninstalling from source might be a good idea.

The Makefile in this pull-request allows a contributor to leverage the make command.
The command `make install` installs the extension in the directory ~/.local/share/gnome-shell/extensions/arc-menu@linxgem33.com, whereas the command `make install` the extension removes.