### PR TITLE
Merge implemented menu-position-feature into Development-Branch

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -32,6 +32,11 @@ const _ = Gettext.gettext;
 
 // Constants
 const SUPER_L = 'Super_L'
+const MENU_POSITION = {
+    Left: 0,
+    Center: 1,
+    Right: 2
+};
 
 /*
  * Arc Menu Preferences Widget
@@ -228,6 +233,64 @@ const GeneralSettingsPage = new Lang.Class({
         menuKeybindingBox.add(menuKeybindingDescriptionBox);
         vbox.add(menuKeybindingBox);
 
+         /*
+         * Menu Position Box
+         */
+         let menuPositionBox = new Gtk.Box({
+            spacing: 20,
+            orientation: Gtk.Orientation.HORIZONTAL,
+            homogeneous: false,
+            margin_left: 5,
+            margin_top: 5,
+            margin_bottom: 5,
+            margin_right: 5
+        });
+        let menuPositionBoxLabel = new Gtk.Label({
+            label: _("Menu position in panel"),
+            use_markup: true,
+            xalign: 0,
+            hexpand: true
+        });
+
+        let menuPositionLeftButton = new Gtk.RadioButton({
+        	label: _('Left')
+        });
+        let menuPositionCenterButton = new Gtk.RadioButton({
+        label: _('Center'),
+        group: menuPositionLeftButton
+        });
+        let menuPositionRightButton = new Gtk.RadioButton({
+            label: _('Right'),
+            group: menuPositionLeftButton
+        });
+        // callback handlers for the radio buttons
+        menuPositionLeftButton.connect('clicked', Lang.bind(this, function() {
+            this.settings.set_enum('position-in-panel', MENU_POSITION.Left);
+        }));
+        menuPositionCenterButton.connect('clicked', Lang.bind(this, function() {
+            this.settings.set_enum('position-in-panel', MENU_POSITION.Center);
+        }));
+        menuPositionRightButton.connect('clicked', Lang.bind(this, function() {
+            this.settings.set_enum('position-in-panel', MENU_POSITION.Right);
+        }));
+
+        switch(this.settings.get_enum('position-in-panel')) {
+            case MENU_POSITION.Left:
+                menuPositionLeftButton.set_active(true);
+                break;
+            case MENU_POSITION.Center:
+                menuPositionCenterButton.set_active(true);
+                break;
+            case MENU_POSITION.Right:
+                menuPositionRightButton.set_active(true);
+                break;
+		}
+
+        menuPositionBox.add(menuPositionBoxLabel);
+        menuPositionBox.add(menuPositionLeftButton);
+        menuPositionBox.add(menuPositionCenterButton);
+        menuPositionBox.add(menuPositionRightButton);
+        vbox.add(menuPositionBox);
 
         this.add(vbox);
     }

--- a/schemas/org.gnome.shell.extensions.arc-menu.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.arc-menu.gschema.xml
@@ -10,6 +10,11 @@
     <value value='1' nick='Super_L'/>
     <value value='2' nick='Super_R'/>
   </enum>
+  <enum id='org.gnome.shell.extensions.arc-menu.menu-position'>
+    <value value="0" nick="Left"/>
+    <value value="1" nick="Center"/>
+    <value value="2" nick="Right"/>
+  </enum>
   <schema path="/org/gnome/shell/extensions/arc-menu/" id="org.gnome.shell.extensions.arc-menu">
     <key name="visible-menus" enum="org.gnome.shell.extensions.arc-menu.visible">
       <default>'ALL'</default>
@@ -40,6 +45,10 @@
       <default><![CDATA[['<Super>x']]]></default>
       <summary>Keybinding to open the Arc Menu.</summary>
       <description>Keybinding to open the Arc Menu.</description>
+    </key>
+    <key name="position-in-panel" enum="org.gnome.shell.extensions.arc-menu.menu-position">
+      <default>'Left'</default>
+      <summary>Position in Panel</summary>
     </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
This PQ implements the menu-position-feature as mentioned in: https://github.com/LinxGem33/Arc-Menu/issues/41. It also fixes the bug described in https://github.com/LinxGem33/Arc-Menu/issues/38.

This commit introduces the following changes:
 * add a Menu Button Manager class that helps us to disable, enable,
   and manage the position of the menu button
 * update the schema file to include menu position
 * update the prefs.js so that the user can specify the menu position: Left, Right, or Center

Signed-off-by: Alexander Rüedlinger <a.rueedlinger@gmail.com>