### PR TITLE
Implement menu-button-customization feature.

### DIFF
--- a/am.js
+++ b/am.js
@@ -1,7 +1,9 @@
 /*
  * Arc Menu: The new applications menu for Gnome 3.
  *
- * Copyright (C) 2017 LinxGem33, Alexander Rüedlinger
+ * Copyright (C) 2017 LinxGem33
+ *
+ * Copyright (C) 2017 Alexander Rüedlinger
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/am.js
+++ b/am.js
@@ -1,0 +1,172 @@
+/*
+ * Arc Menu: The new applications menu for Gnome 3.
+ *
+ * Copyright (C) 2017 LinxGem33, Alexander Rüedlinger
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Import Libraries
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+const Gio = imports.gi.Gio;
+const Gtk = imports.gi.Gtk;
+const GdkPixbuf = imports.gi.GdkPixbuf;
+const Lang = imports.lang;
+
+/**
+ * The module am.js contains all the customized GUI elements
+ * for the preferences widget (prefs.js).
+ * In order to have a consistent UI/UX, every GUI element in the preferences
+ * should be based on a widget from this module.
+ */
+
+/**
+ * Arc Menu Notebook
+ */
+const Notebook = new GObject.Class({
+    Name: 'ArcMenu.ArcMenuNotebook',
+    GTypeName: 'ArcMenuNotebook',
+    Extends: Gtk.Notebook,
+
+    _init: function(params) {
+        this.parent(params);
+    }
+});
+
+/**
+ * Arc Menu Notebook Page
+ */
+const NotebookPage = new GObject.Class({
+    Name: 'ArcMenu.ArcMenuNotebookPage',
+    GTypeName: 'ArcMenuNotebookPage',
+    Extends: Gtk.Box,
+
+    _init: function(title, settings, params) {
+        this.parent({
+            orientation: Gtk.Orientation.VERTICAL,
+            margin_left: 10,
+            margin_right: 10,
+            margin_bottom: 20
+        });
+        this.settings = settings;
+
+        this.title = new Gtk.Label({
+            label: "<b>" + title + "</b>",
+            use_markup: true,
+            xalign: 0
+        });
+    }
+});
+
+/**
+ * Arc Menu icon Button
+ */
+const IconButton = new GObject.Class({
+    Name: 'ArcMenu.ArcMenuIconButton',
+    GTypeName: 'ArcMenuIconButton',
+    Extends: Gtk.Button,
+
+    _init: function(params) {
+        this.parent({});
+        if (params['circular']) {
+            let context = this.get_style_context();
+            context.add_class('circular');
+        }
+        if (params['icon_name']) {
+            let image = new Gtk.Image({
+                icon_name: params['icon_name'],
+                xalign: 0.46
+            });
+            this.add(image);
+        }
+    }
+});
+
+/**
+ * Arc Menu Dialog Window
+ */
+const DialogWindow = new Lang.Class({
+    Name: 'ArcMenu.DialogWindow',
+    GTypeName: 'ArcMenuDialogWindow',
+    Extends: Gtk.Dialog,
+
+    _init: function(title, settings, parent) {
+        this.parent({
+            title: title,
+            transient_for: parent.get_toplevel(),
+            use_header_bar: true,
+            modal: true
+        });
+        let vbox = new Gtk.VBox({
+            spacing: 20,
+            homogeneous: false,
+            margin: 5
+        });
+        this._settings = settings;
+
+        this._createLayout(vbox);
+        this.get_content_area().add(vbox);
+    },
+
+    _createLayout: function(vbox) {
+        throw "Not implemented!";
+    }
+});
+
+/**
+ * Arc Menu Frame Box
+ */
+const FrameBox = new Lang.Class({
+    Name: 'ArcMenu.FrameBox',
+    GTypeName: 'ArcMenuFrameBox',
+    Extends: Gtk.Frame,
+
+    _init: function() {
+        this._listBox = new Gtk.ListBox();
+        this._listBox.set_selection_mode(Gtk.SelectionMode.NONE);
+        this.parent({
+            label_yalign: 0.50,
+            child: this._listBox // this a dirty hack but it does the job
+        });
+    },
+
+    add: function(boxRow) {
+        this._listBox.add(boxRow);
+    }
+});
+
+/**
+ * Arc Menu Frame Box Row
+ */
+const FrameBoxRow = new Lang.Class({
+    Name: 'ArcMenu.FrameBoxRow',
+    GTypeName: 'ArcMenuFrameBoxRow',
+    Extends: Gtk.ListBoxRow,
+
+    _init: function() {
+        this._grid = new Gtk.Grid({
+            margin: 5,
+            column_spacing: 20,
+            row_spacing: 20
+        });
+        this.parent({
+            child: this._grid // this a dirty hack but it does the job
+        });
+    },
+
+    add: function(widget) {
+        this._grid.add(widget);
+    }
+});

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,61 @@
+/*
+ * Arc Menu: The new applications menu for Gnome 3.
+ *
+ * Copyright (C) 2017 LinxGem33, Alexander Rüedlinger
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Common constants that are used in this extension
+const EMPTY_STRING = '';
+const SUPER_L = 'Super_L';
+const SUPER_R = 'Super_R';
+const HOT_KEY = { // See: org.gnome.shell.extensions.arc-menu.menu-hotkey
+    Undefined: 0,
+    Super_L: 1,
+    Super_R: 2,
+    // Inverse mapping
+    0: EMPTY_STRING,  // Note: an empty string is evaluated to false
+    1: SUPER_L,
+    2: SUPER_R
+};
+const MENU_POSITION = { // See: org.gnome.shell.extensions.arc-menu.menu-position
+    Left: 0,
+    Center: 1,
+    Right: 2
+};
+const MENU_APPEARANCE = { // See: org.gnome.shell.extensions.arc-menu.menu-button-icon
+    Icon: 0,
+    Text: 1,
+    Icon_Text: 2,
+    Text_Icon: 3
+};
+const MENU_BUTTON_TEXT = { // See: org.gnome.shell.extensions.arc-menu.menu-button-text
+    System: 0,
+    Custom: 1
+};
+const MENU_BUTTON_ICON = { // See: org.gnome.shell.extensions.arc-menu.menu-button-icon
+    Arc_Menu: 0,
+    System: 1,
+    Custom: 2
+};
+const MENU_ICON_PATH = {
+    Arc_Menu: '/media/icon.svg'
+};
+const ICON_SIZES = [ 16, 24, 32, 40, 48 ];
+const DEFAULT_ICON_SIZE = 22;
+const ARC_MENU_LOGO = {
+    Path: '/media/logo.png',
+    Size: [216, 229] // width, height
+};

--- a/constants.js
+++ b/constants.js
@@ -1,7 +1,9 @@
 /*
  * Arc Menu: The new applications menu for Gnome 3.
  *
- * Copyright (C) 2017 LinxGem33, Alexander Rüedlinger
+ * Copyright (C) 2017 LinxGem33, 
+ * 
+ * Copyright (C) 2017 Alexander Rüedlinger
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/controller.js
+++ b/controller.js
@@ -1,7 +1,9 @@
 /*
  * Arc Menu: The new applications menu for Gnome 3.
  *
- * Copyright (C) 2017 LinxGem33, Alexander Rüedlinger
+ * Copyright (C) 2017 LinxGem33
+ *
+ * Copyright (C) 2017 Alexander Rüedlinger
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/controller.js
+++ b/controller.js
@@ -1,0 +1,285 @@
+/*
+ * Arc Menu: The new applications menu for Gnome 3.
+ *
+ * Copyright (C) 2017 LinxGem33, Alexander Rüedlinger
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Import Libraries
+const Lang = imports.lang;
+const Main = imports.ui.main;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const St = imports.gi.St;
+
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
+const Constants = Me.imports.constants;
+const Helper = Me.imports.helper;
+
+/**
+ * The Menu Settings Controller class is responsible for changing and handling
+ * the settings changes of the Arc Menu.
+ */
+ const MenuSettingsController = new Lang.Class({
+    Name: 'ArcMenu.MenuSettingsController',
+
+    _init: function(settings, menuButton) {
+        this._settings = settings;
+        this._menuButton = menuButton;
+        this._activitiesButtonIsRemoved = false;
+        this._activitiesButton = Main.panel.statusArea['activities'];
+
+        // Create a Hot Corner Manager, a Menu Keybinder as well as a Keybinding Manager
+        this._hotCornerManager = new Helper.HotCornerManager();
+        this._menuHotKeybinder = new Helper.MenuHotKeybinder(Lang.bind(this, function() {
+                this._menuButton.toggleMenu();
+            }));
+        this._keybindingManager = new Helper.KeybindingManager(this._settings);
+
+        this._applySettings();
+    },
+
+    // Load and apply the settings from the arc-menu settings
+    _applySettings: function() {
+        this._updateHotCornerManager();
+        this._setMenuKeybinding();
+        this._updateHotKeyBinder();
+        this._setButtonAppearance();
+        this._setButtonText();
+        this._setButtonIcon();
+        this._setButtonIconSize();
+    },
+
+    // Bind the callbacks for handling the settings changes to the event signals
+    bindSettingsChanges: function() {
+        //settings.connect('changed::visible-menus', function() { appsMenuButton.updateMenu(); });
+        this._settings.connect('changed::disable-activities-hotcorner', Lang.bind(this, this._updateHotCornerManager));
+        this._settings.connect('changed::menu-hotkey', Lang.bind(this, this._updateHotKeyBinder));
+        this._settings.connect('changed::enable-menu-keybinding', Lang.bind(this, this._setMenuKeybinding));
+        this._settings.connect('changed::position-in-panel', Lang.bind(this, this._setButtonPosition));
+        this._settings.connect('changed::menu-button-appearance', Lang.bind(this, this._setButtonAppearance));
+        this._settings.connect('changed::menu-button-text', Lang.bind(this, this._setButtonText));
+        this._settings.connect('changed::custom-menu-button-text', Lang.bind(this, this._setButtonText));
+        this._settings.connect('changed::menu-button-icon', Lang.bind(this, this._setButtonIcon));
+        this._settings.connect('changed::custom-menu-button-icon', Lang.bind(this, this._setButtonIcon));
+        this._settings.connect('changed::custom-menu-button-icon-size', Lang.bind(this, this._setButtonIconSize));
+        this._settings.connect('changed::enable-menu-button-arrow', Lang.bind(this, this._setMenuButtonArrow));
+    },
+
+    _updateHotCornerManager: function() {
+        if (this._settings.get_boolean('disable-activities-hotcorner')) {
+            this._hotCornerManager.disableHotCorners();
+        } else {
+            this._hotCornerManager.enableHotCorners();
+        }
+    },
+
+    _updateHotKeyBinder: function() {
+        let hotKeyPos = this._settings.get_enum('menu-hotkey');
+        if (hotKeyPos != Constants.HOT_KEY.Undefined) {
+            let hotKey = Constants.HOT_KEY[hotKeyPos];
+            this._menuHotKeybinder.enableHotKey(hotKey);
+        }
+    },
+
+    _setMenuKeybinding: function() {
+       if (this._settings.get_boolean('enable-menu-keybinding')) {
+            this._keybindingManager.bind('menu-keybinding-text', 'menu-keybinding',
+                Lang.bind(this, function() {
+                    this._menuButton.toggleMenu();
+                }));
+        } else {
+            this._keybindingManager.unbind('menu-keybinding-text');
+        }
+    },
+
+    // Place the menu button to main panel as specified in the settings
+    _setButtonPosition: function() {
+        if (this._isButtonEnabled()) {
+            this._removeMenuButtonFromMainPanel();
+            this._addMenuButtonToMainPanel();
+        }
+    },
+
+    // Change the menu button appearance as specified in the settings
+    _setButtonAppearance: function() {
+        let menuButtonWidget = this._menuButton.getWidget();
+        switch (this._settings.get_enum('menu-button-appearance')) {
+            case Constants.MENU_APPEARANCE.Text:
+                menuButtonWidget.hidePanelIcon();
+                menuButtonWidget.showPanelText();
+                break;
+            case Constants.MENU_APPEARANCE.Icon_Text:
+                menuButtonWidget.hidePanelIcon();
+                menuButtonWidget.hidePanelText();
+                menuButtonWidget.showPanelIcon();
+                menuButtonWidget.showPanelText();
+                break;
+            case Constants.MENU_APPEARANCE.Text_Icon:
+                menuButtonWidget.hidePanelIcon();
+                menuButtonWidget.hidePanelText();
+                menuButtonWidget.showPanelText();
+                menuButtonWidget.showPanelIcon();
+                break;
+            case Constants.MENU_APPEARANCE.Icon:
+            default:
+                menuButtonWidget.hidePanelText();
+                menuButtonWidget.showPanelIcon();
+        }
+        this._setMenuButtonArrow();
+    },
+
+    _setMenuButtonArrow: function() {
+        let menuButtonWidget = this._menuButton.getWidget();
+        if (this._settings.get_boolean('enable-menu-button-arrow')){
+            menuButtonWidget.hideArrowIcon();
+            menuButtonWidget.showArrowIcon();
+        } else {
+            menuButtonWidget.hideArrowIcon();
+        }
+    },
+
+    // Update the text of the menu button as specified in the settings
+    _setButtonText: function() {
+        // Update the text of the menu button
+        let menuButtonWidget = this._menuButton.getWidget();
+        let label = menuButtonWidget.getPanelLabel();
+
+        switch (this._settings.get_enum('menu-button-text')) {
+            case Constants.MENU_BUTTON_TEXT.Custom:
+                let customTextLabel = this._settings.get_string('custom-menu-button-text');
+                label.set_text(customTextLabel);
+                break;
+            case Constants.MENU_BUTTON_TEXT.System:
+            default:
+                let systemTextLabel = _('Applications');
+                label.set_text(systemTextLabel);
+        }
+    },
+
+    // Update the icon of the menu button as specified in the settings
+    _setButtonIcon: function() {
+        let iconFilepath = this._settings.get_string('custom-menu-button-icon');
+        let menuButtonWidget = this._menuButton.getWidget();
+        let stIcon = menuButtonWidget.getPanelIcon();
+
+        if (stIcon.has_style_class_name('popup-menu-icon')) {
+            stIcon.remove_style_class_name('popup-menu-icon');
+        }
+
+        switch (this._settings.get_enum('menu-button-icon')) {
+            case Constants.MENU_BUTTON_ICON.Custom:
+                if (GLib.file_test(iconFilepath, GLib.FileTest.EXISTS)) {
+                    stIcon.set_gicon(Gio.icon_new_for_string(iconFilepath));
+                    break;
+                }
+            case Constants.MENU_BUTTON_ICON.Arc_Menu:
+                let arcMenuIconPath = Me.path + Constants.MENU_ICON_PATH.Arc_Menu;
+                if (GLib.file_test(arcMenuIconPath, GLib.FileTest.EXISTS)) {
+                    stIcon.set_gicon(Gio.icon_new_for_string(arcMenuIconPath));
+                    break;
+                }
+            case Constants.MENU_BUTTON_ICON.System:
+            default:
+                stIcon.set_icon_name('start-here-symbolic');
+                stIcon.add_style_class_name('popup-menu-icon');
+        }
+    },
+
+    // Update the icon of the menu button as specified in the settings
+    _setButtonIconSize: function() {
+        let scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+        let menuButtonWidget = this._menuButton.getWidget();
+        let stIcon = menuButtonWidget.getPanelIcon();
+        let iconSize = this._settings.get_double('custom-menu-button-icon-size');
+        let size = iconSize*scaleFactor;
+        stIcon.set_icon_size(size);
+    },
+
+    // Get the current position of the menu button and its associated position order
+    _getMenuPositionTuple: function() {
+        switch (this._settings.get_enum('position-in-panel')) {
+            case Constants.MENU_POSITION.Center:
+                return ['center', 0];
+            case Constants.MENU_POSITION.Right:
+                return ['right', -1];
+            case Constants.MENU_POSITION.Left:
+            default:
+                return ['left', 0];
+        }
+    },
+
+    // Remove the activities button from the main panel
+    _removeActivitiesButtonFromMainPanel: function() {
+        if (!this._activitiesButtonIsRemoved) {
+            Main.panel._leftBox.remove_child(this._activitiesButton.container);
+            this._activitiesButtonIsRemoved = true;
+        }
+    },
+
+    // Add or restore the activities button on the main panel
+    _addActivitiesButtonToMainPanel: function() {
+        if (this._activitiesButtonIsRemoved) {
+            // Retsore the activities button at the default position
+            Main.panel._leftBox.add_child(this._activitiesButton.container);
+            Main.panel._leftBox.set_child_at_index(this._activitiesButton.container, 0);
+            this._activitiesButtonIsRemoved = false;
+        }
+    },
+
+    // Add the menu button to the main panel
+    _addMenuButtonToMainPanel: function() {
+        let [menuPosition, order] = this._getMenuPositionTuple();
+        Main.panel.addToStatusArea('arc-menu', this._menuButton, order, menuPosition);
+    },
+
+    // Remove the menu button from the main panel
+    _removeMenuButtonFromMainPanel: function() {
+        Main.panel.menuManager.removeMenu(this._menuButton.menu);
+        Main.panel.statusArea['arc-menu'] = null;
+    },
+
+    // Enable the menu button
+    enableButton: function() {
+        this._removeActivitiesButtonFromMainPanel(); // disable the activities button
+        this._addMenuButtonToMainPanel();
+    },
+
+    // Disable the menu button
+    disableButton: function() {
+        this._removeMenuButtonFromMainPanel();
+        this._addActivitiesButtonToMainPanel(); // restore the activities button
+    },
+
+    _isButtonEnabled: function() {
+        return Main.panel.statusArea['arc-menu'] !== null;
+    },
+
+    // Destroy this object
+    destroy: function() {
+        // Clean up and restore the default behaviour
+        if (this._isButtonEnabled()) {
+            this._disableButton();
+        }
+        this._hotCornerManager.destroy();
+        this._menuHotKeybinder.destroy();
+        this._keybindingManager.destroy();
+
+        this._settings = null;
+        this._activitiesButton = null;
+        this._menuButton = null;
+    }
+});

--- a/controller.js
+++ b/controller.js
@@ -92,6 +92,8 @@ const Helper = Me.imports.helper;
         if (hotKeyPos != Constants.HOT_KEY.Undefined) {
             let hotKey = Constants.HOT_KEY[hotKeyPos];
             this._menuHotKeybinder.enableHotKey(hotKey);
+        } else {
+            this._menuHotKeybinder.disableHotKey();
         }
     },
 

--- a/extension.js
+++ b/extension.js
@@ -3,7 +3,8 @@
  *
  * Original work: Copyright (C) 2015 Giovanni Campagna
  * Modified work: Copyright (C) 2016-2017 Zorin OS Technologies Ltd.
- * Modified work: Copyright (C) 2017 LinxGem33, Alexander Rüedlinger
+ * Modified work: Copyright (C) 2017 LinxGem33
+ * Modified work: Copyright (C) 2017 Alexander Rüedlinger
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/extension.js
+++ b/extension.js
@@ -3,7 +3,7 @@
  *
  * Original work: Copyright (C) 2015 Giovanni Campagna
  * Modified work: Copyright (C) 2016-2017 Zorin OS Technologies Ltd.
- * Modified work: Copyright (C) 2017 LinxGem33. 
+ * Modified work: Copyright (C) 2017 LinxGem33, Alexander Rüedlinger
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,15 +36,15 @@ const AppDisplay = imports.ui.appDisplay;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Menu = Me.imports.menu;
-const Helper = Me.imports.helper;
+const Controller = Me.imports.controller;
 const Convenience = Me.imports.convenience;
 
 // Initialize panel button variables
 let settings;
+let settingsController;
 let appsMenuButton;
 let activitiesButton;
 let oldGetAppFromSource;
-let menuButtonManager;
 
 // Initialize menu language translations
 function init(metadata) {
@@ -56,23 +56,24 @@ function enable() {
     settings = Convenience.getSettings(Me.metadata['settings-schema']);
     appsMenuButton = new Menu.ApplicationsButton(settings);
 
-    // Create a Menu Button Manager that is responsible for enabling, disabling,
-    // and managing the position of the menu button
-    menuButtonManager = new Helper.MenuButtonManager(settings, appsMenuButton);
-    menuButtonManager.enableButton();
+    // Create a Menu Controller that is responsible for controlling
+    // and managing the menu as well as the menu button.
+    settingsController = new Controller.MenuSettingsController(settings, appsMenuButton);
+    settingsController.enableButton();
+    settingsController.bindSettingsChanges();
 
-    bindSettingsChanges();
     oldGetAppFromSource = Dash.getAppFromSource;
     Dash.getAppFromSource = getAppFromSource;
 }
 
 // Disable the extension
 function disable() {
-    menuButtonManager.destroy();
+    settingsController.disableButton();
+    settingsController.destroy();
     appsMenuButton.destroy();
     settings.run_dispose();
 
-    menuButtonManager = null;
+    settingsController =  null;
     settings = null;
     appsMenuButton = null;
     activitiesButton = null;
@@ -88,14 +89,4 @@ function getAppFromSource(source) {
     } else {
         return null;
     }
-}
-
-function bindSettingsChanges() {
-    settings.connect('changed::visible-menus', function() { appsMenuButton.updateMenu(); });
-    settings.connect('changed::disable-activities-hotcorner', function() { appsMenuButton.updateMenu(); });
-    settings.connect('changed::menu-hotkey', function() { appsMenuButton.updateMenu(); });
-    settings.connect('changed::enable-menu-keybinding', function() { appsMenuButton.updateMenu(); });
-    settings.connect('changed::position-in-panel', function() {
-        menuButtonManager.updateButtonPosition();
-    });
 }

--- a/helper.js
+++ b/helper.js
@@ -1,7 +1,8 @@
 /*
  * Arc Menu: The new applications menu for Gnome 3.
  *
- * Copyright (C) 2017 LinxGem33, Alexander Rüedlinger
+ * Copyright (C) 2017 LinxGem33
+ * Copyright (C) 2017 Alexander Rüedlinger
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/helper.js
+++ b/helper.js
@@ -1,7 +1,7 @@
 /*
  * Arc Menu: The new applications menu for Gnome 3.
  *
- * Copyright (C) 2017 LinxGem33, lexruee 
+ * Copyright (C) 2017 LinxGem33, Alexander Rüedlinger
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,28 +22,16 @@ const Lang = imports.lang;
 const Main = imports.ui.main;
 const Meta = imports.gi.Meta;
 const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
 const Shell = imports.gi.Shell;
+
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+const Constants = Me.imports.constants;
 
-// Constants
-const SUPER_L = 'Super_L';
-const EMPTY_STRING = '';
+// Local constants
 const MUTTER_SCHEMA = 'org.gnome.mutter';
 const WM_KEYBINDINGS_SCHEMA = 'org.gnome.desktop.wm.keybindings';
-const ARC_MENU_HOT_KEY = {
-    0: EMPTY_STRING, // Note: an empty string is evaluated to false
-    1: 'Super_L',
-    2: 'Super_R'
-};
-const MENU_POSITION = {
-    Left: 0,
-    Center: 1,
-    Right: 2
-};
-
 
 /**
  * The Menu HotKeybinder class helps us to bind and unbind a menu hotkey
@@ -52,31 +40,29 @@ const MENU_POSITION = {
 const MenuHotKeybinder = new Lang.Class({
     Name: 'ArcMenu.MenuHotKeybinder',
 
-    _init: function(settings, menuToggler) {
-        this._settings = settings;
+    _init: function(menuToggler) {
         this._menuToggler = menuToggler;
         this._mutterSettings = new Gio.Settings({ 'schema': MUTTER_SCHEMA });
         this._wmKeybindings = new Gio.Settings({ 'schema': WM_KEYBINDINGS_SCHEMA });
         this._keybindingHandlerId = Main.layoutManager.connect('startup-complete',
-                                        Lang.bind(this, this._setKeybindingHandler));
+            Lang.bind(this, this._setKeybindingHandler));
         this._setKeybindingHandler();
     },
 
-    // Enable the menu key binding
-    enable: function() {
-        let keybinding = this._getMenuHotKeybinding();
-        if(keybinding == SUPER_L) {
+    // Enable a hot key for opening the menu
+    enableHotKey: function(hotkey) {
+        if (hotkey == Constants.SUPER_L) {
             this._disableOverlayKey();
         } else {
             this._enableOverlayKey();
         }
-        this._wmKeybindings.set_strv('panel-main-menu', [keybinding]);
+        this._wmKeybindings.set_strv('panel-main-menu', [hotkey]);
     },
 
-    // Disable the menu key binding
-    disable: function() {
+    // Disable the set hot key for opening the menu
+    disableHotKey: function() {
         // Restore the default settings
-        if(this._isOverlayKeyDisabled()) {
+        if (this._isOverlayKeyDisabled()) {
             this._enableOverlayKey();
         }
         let defaultPanelMainMenu = this._wmKeybindings.get_default_value('panel-main-menu');
@@ -90,22 +76,16 @@ const MenuHotKeybinder = new Lang.Class({
             Lang.bind(this, this._menuToggler));
     },
 
-    // Get the menu key binding from the arc menu settings
-    _getMenuHotKeybinding: function() {
-        let pos = this._settings.get_enum('menu-hotkey');
-        return ARC_MENU_HOT_KEY[pos];
-    },
-
      // Check if the overlay keybinding is disabled in mutter
     _isOverlayKeyDisabled: function() {
-        return this._mutterSettings.get_string('overlay-key') == EMPTY_STRING;
+        return this._mutterSettings.get_string('overlay-key') == Constants.EMPTY_STRING;
     },
 
     // Disable the overlay keybinding in mutter
     _disableOverlayKey: function() {
         // Simple hack to deactivate the overlay key by setting
         // the keybinding of the overlay key to an empty string
-        this._mutterSettings.set_string('overlay-key', EMPTY_STRING);
+        this._mutterSettings.set_string('overlay-key', Constants.EMPTY_STRING);
     },
 
     // Enable and restore the default settings of the overlay key in mutter
@@ -121,8 +101,8 @@ const MenuHotKeybinder = new Lang.Class({
     // Destroy this object
     destroy: function() {
         // Clean up and restore the default behaviour
-        this.disable();
-        if(this._keybindingHandlerId) {
+        this.disableHotKey();
+        if (this._keybindingHandlerId) {
             // Disconnect the keybinding handler
             Main.layoutManager.disconnect(this._keybindingHandlerId);
             this._keybindingHandlerId = null;
@@ -144,7 +124,7 @@ const KeybindingManager = new Lang.Class({
 
     // Bind a keybinding to a keybinding handler
     bind: function(keybindingNameKey, keybindingValueKey, keybindingHandler) {
-        if(!this._keybindings.has(keybindingNameKey)) {
+        if (!this._keybindings.has(keybindingNameKey)) {
             this._keybindings.set(keybindingNameKey, keybindingValueKey);
             let keybinding = this._settings.get_string(keybindingNameKey);
             this._setKeybinding(keybindingNameKey, keybinding);
@@ -159,18 +139,9 @@ const KeybindingManager = new Lang.Class({
         return false;
     },
 
-    // Update all keybindings
-    update: function() {
-        let keybindings = this._keybindings.keys();
-        keybindings.forEach(function(keybindingNameKey) {
-            let keybinding = this._settings.get_string(keybindingNameKey);
-            this._setKeybinding(keybindingNameKey, keybinding);
-        });
-    },
-
     // Set or update a keybinding in the Arc Menu settings
     _setKeybinding: function(keybindingNameKey, keybinding) {
-        if(this._keybindings.has(keybindingNameKey)) {
+        if (this._keybindings.has(keybindingNameKey)) {
             let keybindingValueKey = this._keybindings.get(keybindingNameKey);
             let [key, mods] = Gtk.accelerator_parse(keybinding);
 
@@ -185,7 +156,7 @@ const KeybindingManager = new Lang.Class({
 
     // Unbind a keybinding
     unbind: function(keybindingNameKey) {
-        if(this._keybindings.has(keybindingNameKey)) {
+        if (this._keybindings.has(keybindingNameKey)) {
             let keybindingValueKey = this._keybindings.get(keybindingNameKey);
             Main.wm.removeKeybinding(keybindingValueKey);
             this._keybindings.delete(keybindingNameKey);
@@ -197,7 +168,7 @@ const KeybindingManager = new Lang.Class({
     // Destroy this object
     destroy: function() {
         let keyIter = this._keybindings.keys();
-        for(let i = 0; i < this._keybindings.size; i++) {
+        for (let i = 0; i < this._keybindings.size; i++) {
 	        let keybindingNameKey = keyIter.next();
 	        this.unbind(keybindingNameKey);
         }
@@ -216,138 +187,45 @@ const HotCornerManager = new Lang.Class({
     },
 
     // Get all hot corners from the main layout manager
-    getHotCorners: function() {
+    _getHotCorners: function() {
         return Main.layoutManager.hotCorners;
-    },
-
-    // Disable all hot corners
-    disableHotCorners: function() {
-        let hotCorners = this.getHotCorners();
-        // Monkey patch each hot corner
-        hotCorners.forEach(function(corner) {
-            if(corner) {
-                corner._toggleOverview = function() {};
-                corner._pressureBarrier._trigger = function() {};
-            }
-        });
-        if(!this._hotCornersChangedId) {
-            this._hotCornersChangedId = Main.layoutManager.connect('hot-corners-changed',
-                Lang.bind(this, function() {
-                    this.disableHotcorners();
-                }));
-        }
     },
 
     // Enable all hot corners
     enableHotCorners: function() {
-        if(this._hotCornersChangedId) { // Restore the default behaviour
-            // Disconnect the callback and recreate the hot corners
+        if (this._hotCornersChangedId) {
+            // Restore the default behaviour and connect
+            // the callback and recreate the hot corners
             Main.layoutManager.disconnect(this._hotCornersChangedId);
             Main.layoutManager._updateHotCorners();
             this._hotCornersChangedId = null;
         }
     },
-    
+
+    // Disable all hot corners
+    disableHotCorners: function() {
+        let hotCorners = this._getHotCorners();
+        // Monkey patch each hot corner
+        hotCorners.forEach(function(corner) {
+            if (corner) {
+                corner._toggleOverview = function() {};
+                corner._pressureBarrier._trigger = function() {};
+            }
+        });
+        if (!this._hotCornersChangedId) {
+            this._hotCornersChangedId = Main.layoutManager.connect('hot-corners-changed',
+            Lang.bind(this, function() {
+                this.enableHotCorners(false);
+            }));
+        }
+    },
+
     // Destroy this object
     destroy: function() {
         // Clean up and restore the default behaviour
-        if(this._hotCornersChangedId) {
+        if (this._hotCornersChangedId) {
             this.enableHotCorners();
         }
        this._hotCornersChangedId = null;
-    }
-});
-
-/**
- * The Menu Button Manager class is responsible for enabling, disabling,
- * and managing the position of the menu button.
- * As such, it helps us to position the menu button at the left, at the center,
- * or at the right of the gnome-shell main panel.
- */
- const MenuButtonManager = new Lang.Class({
-    Name: 'ArcMenu.MenuPositionManager',
-
-    _init: function(settings, menuButton) {
-        this._settings = settings;
-        this._menuButton = menuButton;
-        this._activitiesButtonIsRemoved = false;
-        this._activitiesButton = Main.panel.statusArea['activities'];
-    },
-
-    // Get the current position of the menu button and its associated position order
-    _getMenuPositionTuple: function() {
-        switch(this._settings.get_enum('position-in-panel')) {
-            case MENU_POSITION.Left:
-                return ['left', 0];
-            case MENU_POSITION.Center:
-                return ['center', 0];
-            case MENU_POSITION.Right:
-                return ['right', -1];
-            default:
-                return ['left', 0];
-        }
-    },
-
-    // Remove the activities button from the main panel
-    _removeActivitiesButton: function() {
-        if(!this._activitiesButtonIsRemoved) {
-            Main.panel._leftBox.remove_child(this._activitiesButton.container);
-            this._activitiesButtonIsRemoved = true;
-        }
-    },
-
-    // Add or restore the activities button on the main panel
-    _addActivitiesButton: function() {
-        if(this._activitiesButtonIsRemoved) {
-            // Retsore the activities button at the default position
-            Main.panel._leftBox.add_child(this._activitiesButton.container);
-            Main.panel._leftBox.set_child_at_index(this._activitiesButton.container, 0);
-            this._activitiesButtonIsRemoved = false;
-        }
-    },
-
-    // Add the menu button to the main panel
-    _addMenuButton: function() {
-        let [menuPosition, order] = this._getMenuPositionTuple();
-        Main.panel.addToStatusArea('arc-menu', this._menuButton, order, menuPosition);
-    },
-
-    // Remove the menu button from the main panel
-    _removeMenuButton: function() {
-        Main.panel.menuManager.removeMenu(this._menuButton.menu);
-        Main.panel.statusArea['arc-menu'] = null;
-    },
-
-    // Enable the menu button and disable the activities button
-    enableButton: function() {
-        this._removeActivitiesButton();
-        this._addMenuButton();
-    },
-
-    // Disable the menu button and restore the default activities button
-    disableButton: function() {
-        this._removeMenuButton();
-        this._addActivitiesButton();
-    },
-
-    // Place the menu button to main panel as specified in the settings
-    updateButtonPosition: function() {
-        this._removeMenuButton();
-        this._addMenuButton();
-    },
-
-    _isButtonEnabled: function() {
-        return Main.panel.statusArea['arc-menu'] !== null;
-    },
-
-    // Destroy this object
-    destroy: function() {
-        // Clean up and restore the default behaviour
-        if(this._isButtonEnabled()) {
-            this.disableButton();
-        }
-        this._settings = null;
-        this._activitiesButton = null;
-        this._menuButton = null;
     }
 });

--- a/prefs.js
+++ b/prefs.js
@@ -1,7 +1,7 @@
 /*
  * Arc Menu: The new applications menu for Gnome 3.
  *
- * Copyright (C) 2017 LinxGem33, lexruee. 
+ * Copyright (C) 2017 LinxGem33, Alexander Rüedlinger
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,16 +28,11 @@ const Lang = imports.lang;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
+const Constants = Me.imports.constants;
+const AM = Me.imports.am;
+
 const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
 const _ = Gettext.gettext;
-
-// Constants
-const SUPER_L = 'Super_L'
-const MENU_POSITION = {
-    Left: 0,
-    Center: 1,
-    Right: 2
-};
 
 /*
  * Arc Menu Preferences Widget
@@ -55,54 +50,18 @@ const ArcMenuPreferencesWidget= new GObject.Class({
         });
         this.settings = Convenience.getSettings(Me.metadata['settings-schema']);
         
-        let notebook = new ArcMenuNotebook();
+        let notebook = new AM.Notebook();
         
         let generalSettingsPage = new GeneralSettingsPage(this.settings);
         notebook.append_page(generalSettingsPage, generalSettingsPage.title);
 
+        let appearancePage = new AppearanceSettingsPage(this.settings);
+        notebook.append_page(appearancePage, appearancePage.title);
+
         let aboutPage = new AboutPage(this.settings);
         notebook.append_page(aboutPage, aboutPage.title);
 
-
         this.add(notebook);
-    }
-});
-
-/*
- * Arc Menu Notebook
- */
-const ArcMenuNotebook = new GObject.Class({
-    Name: 'ArcMenu.ArcMenuNotebook',
-    GTypeName: 'ArcMenuNotebook',
-    Extends: Gtk.Notebook,
-
-    _init: function(params) {
-        this.parent(params);
-    }
-});
-
-/*
- * Arc Menu Notebook Page
- */
-const ArcMenuNotebookPage = new GObject.Class({
-    Name: 'ArcMenu.ArcMenuNotebookPage',
-    GTypeName: 'ArcMenuNotebookPage',
-    Extends: Gtk.Box,
-
-    _init: function(title, settings, params) {
-        this.parent({
-            orientation: Gtk.Orientation.VERTICAL,
-            margin_left: 10,
-            margin_right: 10,
-            margin_bottom: 20
-        });
-        this.settings = settings;
-
-        this.title = new Gtk.Label({
-            label: _("<b>" + title + "</b>"),
-            use_markup: true,
-            xalign: 0
-        });
     }
 });
 
@@ -111,22 +70,19 @@ const ArcMenuNotebookPage = new GObject.Class({
  */
 const GeneralSettingsPage = new Lang.Class({
     Name: 'GeneralSettingsPage',
-    Extends: ArcMenuNotebookPage,
-    
+    Extends: AM.NotebookPage,
+
     _init: function(settings, params) {
         this.parent(_('General'), settings, params);
-        
+
         // Container for all general settings boxes
-        let vbox = new Gtk.Box({
-            orientation: Gtk.Orientation.VERTICAL
-        });
+        let vbox = new Gtk.VBox({});
 
         /*
          * Hot Corner Box
          */
-        let disableHotCornerBox = new Gtk.Box({
+        let disableHotCornerBox = new Gtk.HBox({
             spacing: 20,
-            orientation: Gtk.Orientation.HORIZONTAL,
             homogeneous: false,
             margin_left: 5,
             margin_top: 5,
@@ -151,9 +107,8 @@ const GeneralSettingsPage = new Lang.Class({
         /*
          * Menu Hotkey Box
          */
-        let enableMenuHotkeyBox = new Gtk.Box({
+        let enableMenuHotkeyBox = new Gtk.HBox({
             spacing: 20,
-            orientation: Gtk.Orientation.HORIZONTAL,
             homogeneous: false,
             margin_left: 5,
             margin_top: 5,
@@ -181,12 +136,9 @@ const GeneralSettingsPage = new Lang.Class({
         /*
          * Menu Keybinding Box
          */
-        let menuKeybindingBox = new Gtk.Box({
-            orientation: Gtk.Orientation.VERTICAL
-        });
-        let enableMenuKeybindingBox = new Gtk.Box({
+        let menuKeybindingBox = new Gtk.VBox({});
+        let enableMenuKeybindingBox = new Gtk.HBox({
             spacing: 20,
-            orientation: Gtk.Orientation.HORIZONTAL,
             homogeneous: false,
             margin_left: 5,
             margin_top: 5,
@@ -198,9 +150,8 @@ const GeneralSettingsPage = new Lang.Class({
             xalign: 0,
             hexpand: true
         });
-        let menuKeybindingDescriptionBox = new Gtk.Box({
+        let menuKeybindingDescriptionBox = new Gtk.HBox({
             spacing: 20,
-            orientation: Gtk.Orientation.HORIZONTAL,
             homogeneous: false,
             margin_left: 5,
             margin_bottom: 5,
@@ -213,7 +164,7 @@ const GeneralSettingsPage = new Lang.Class({
         let enableMenuKeybindingSwitch = new Gtk.Switch({ halign: Gtk.Align.END });
         enableMenuKeybindingSwitch.set_active(this.settings.get_boolean('enable-menu-keybinding'));
         enableMenuKeybindingSwitch.connect('notify::active', Lang.bind(this, function(check) {
-        this.settings.set_boolean('enable-menu-keybinding', check.get_active());
+            this.settings.set_boolean('enable-menu-keybinding', check.get_active());
         }));
         let menuKeybindingEntry = new Gtk.Entry({ halign: Gtk.Align.END });
         menuKeybindingEntry.set_width_chars(15);
@@ -234,12 +185,73 @@ const GeneralSettingsPage = new Lang.Class({
         menuKeybindingBox.add(menuKeybindingDescriptionBox);
         vbox.add(menuKeybindingBox);
 
-         /*
-         * Menu Position Box
+
+        this.add(vbox);
+    }
+});
+
+/*
+ * TODO: Appearance Settings Page
+ */
+const AppearanceSettingsPage = new Lang.Class({
+    Name: 'AppearanceSettingsPage',
+    Extends: AM.NotebookPage,
+
+    _init: function(settings, params) {
+        this.parent(_('Appearance'), settings, params);
+
+        // Container for all general settings boxes
+        let vbox = new Gtk.VBox({});
+
+        /*
+         * Menu Button Appearance Box
          */
-         let menuPositionBox = new Gtk.Box({
+         let menuButtonAppearanceBox = new Gtk.Box({
             spacing: 20,
             orientation: Gtk.Orientation.HORIZONTAL,
+            homogeneous: false,
+            margin_left: 5,
+            margin_top: 5,
+            margin_bottom: 5,
+            margin_right: 5
+        });
+        let menuButtonAppearanceLabel = new Gtk.Label({
+            label: _("Customize menu button appearance"),
+            use_markup: true,
+            xalign: 0,
+            hexpand: true
+        });
+        let menuButtonAppearanceSettingsButton = new AM.IconButton({
+            circular: true,
+            icon_name: 'emblem-system-symbolic'
+        });
+        let menuButtonAppearanceCombo = new Gtk.ComboBoxText({ halign:Gtk.Align.END });
+        menuButtonAppearanceCombo.append_text(_("Icon"));
+        menuButtonAppearanceCombo.append_text(_("Text"));
+        menuButtonAppearanceCombo.append_text(_("Icon and Text"));
+        menuButtonAppearanceCombo.append_text(_("Text and Icon"));
+        menuButtonAppearanceCombo.set_active(this.settings.get_enum('menu-button-appearance'));
+        menuButtonAppearanceCombo.connect('changed', Lang.bind (this, function(widget) {
+                this.settings.set_enum('menu-button-appearance', widget.get_active());
+        }));
+
+        // Extra settings for the appearance of the menu button
+        menuButtonAppearanceSettingsButton.connect('clicked',
+        Lang.bind(this, function() {
+            let dialog = new MenuButtonCustomizationWindow(this.settings, this);
+            dialog.show_all();
+        }));
+
+        menuButtonAppearanceBox.add(menuButtonAppearanceLabel);
+        menuButtonAppearanceBox.add(menuButtonAppearanceSettingsButton);
+        menuButtonAppearanceBox.add(menuButtonAppearanceCombo);
+        vbox.add(menuButtonAppearanceBox);
+
+        /*
+         * Menu Position Box
+         */
+        let menuPositionBox = new Gtk.HBox({
+            spacing: 20,
             homogeneous: false,
             margin_left: 5,
             margin_top: 5,
@@ -266,26 +278,26 @@ const GeneralSettingsPage = new Lang.Class({
         });
         // callback handlers for the radio buttons
         menuPositionLeftButton.connect('clicked', Lang.bind(this, function() {
-            this.settings.set_enum('position-in-panel', MENU_POSITION.Left);
+            this.settings.set_enum('position-in-panel', Constants.MENU_POSITION.Left);
         }));
         menuPositionCenterButton.connect('clicked', Lang.bind(this, function() {
-            this.settings.set_enum('position-in-panel', MENU_POSITION.Center);
+            this.settings.set_enum('position-in-panel', Constants.MENU_POSITION.Center);
         }));
         menuPositionRightButton.connect('clicked', Lang.bind(this, function() {
-            this.settings.set_enum('position-in-panel', MENU_POSITION.Right);
+            this.settings.set_enum('position-in-panel', Constants.MENU_POSITION.Right);
         }));
 
         switch(this.settings.get_enum('position-in-panel')) {
-            case MENU_POSITION.Left:
+            case Constants.MENU_POSITION.Left:
                 menuPositionLeftButton.set_active(true);
                 break;
-            case MENU_POSITION.Center:
+            case Constants.MENU_POSITION.Center:
                 menuPositionCenterButton.set_active(true);
                 break;
-            case MENU_POSITION.Right:
+            case Constants.MENU_POSITION.Right:
                 menuPositionRightButton.set_active(true);
                 break;
-		}
+        }
 
         menuPositionBox.add(menuPositionBoxLabel);
         menuPositionBox.add(menuPositionLeftButton);
@@ -297,12 +309,178 @@ const GeneralSettingsPage = new Lang.Class({
     }
 });
 
+const MenuButtonCustomizationWindow = new Lang.Class({
+    Name: 'MenuButtonCustomizationWindow',
+    Extends: AM.DialogWindow,
+
+    _init: function(settings, parent) {
+        this.parent(_('Button appearance'), settings, parent);
+    },
+
+    _createLayout: function(vbox) {
+        /*
+        * Text Appearance Frame
+        */
+        let menuButtonTextFrame = new AM.FrameBox();
+
+        //first row
+        let menuButtonTextBoxRow = new AM.FrameBoxRow();
+        let menuButtonTextLabel = new Gtk.Label({
+            label: _('Text for the menu button'),
+            use_markup: true,
+            xalign: 0,
+            hexpand: true
+        });
+        let systemTextButton = new Gtk.RadioButton({
+            label: _('System text')
+        });
+        let customTextButton = new Gtk.RadioButton({
+            label: _('Custom text'),
+            group: systemTextButton
+        });
+        //TODO: fix this hack
+        systemTextButton.set_active(this._settings.get_enum('menu-button-text') == Constants.MENU_BUTTON_TEXT.System);
+        customTextButton.set_active(this._settings.get_enum('menu-button-text') == Constants.MENU_BUTTON_TEXT.Custom);
+        systemTextButton.connect('clicked', Lang.bind(this, function() {
+            this._settings.set_enum('menu-button-text', Constants.MENU_BUTTON_TEXT.System);
+        }));
+        customTextButton.connect('clicked', Lang.bind(this, function() {
+            this._settings.set_enum('menu-button-text', Constants.MENU_BUTTON_TEXT.Custom);
+        }));
+        menuButtonTextBoxRow.add(menuButtonTextLabel);
+        menuButtonTextBoxRow.add(systemTextButton);
+        menuButtonTextBoxRow.add(customTextButton);
+        menuButtonTextFrame.add(menuButtonTextBoxRow);
+
+        // second row
+        let menuButtonCustomTextBoxRow = new AM.FrameBoxRow();
+        let menuButtonCustomTextLabel = new Gtk.Label({
+            label: _('Set custom text for the menu button'),
+            use_markup: true,
+            xalign: 0,
+            hexpand: true
+        });
+
+        let menuButtonCustomTextEntry = new Gtk.Entry({ halign: Gtk.Align.END });
+        menuButtonCustomTextEntry.set_width_chars(15);
+        menuButtonCustomTextEntry.set_text(this._settings.get_string('custom-menu-button-text'));
+        menuButtonCustomTextEntry.connect('changed', Lang.bind(this, function(entry) {
+        let customMenuButtonText = entry.get_text();
+            this._settings.set_string('custom-menu-button-text', customMenuButtonText);
+        }));
+        menuButtonCustomTextBoxRow.add(menuButtonCustomTextLabel);
+        menuButtonCustomTextBoxRow.add(menuButtonCustomTextEntry);
+        menuButtonTextFrame.add(menuButtonCustomTextBoxRow);
+
+        // third row
+        let menuButtonArrowIconBoxRow = new AM.FrameBoxRow();
+        let menuButtonArrowIconLabel = new Gtk.Label({
+            label: _('Enable the arrow icon beside the button text'),
+            use_markup: true,
+            xalign: 0,
+            hexpand: true
+        });
+        let enableArrowIconSwitch = new Gtk.Switch({ halign: Gtk.Align.END });
+        enableArrowIconSwitch.set_active(this._settings.get_boolean('enable-menu-button-arrow'));
+        enableArrowIconSwitch.connect('notify::active', Lang.bind(this, function(check) {
+             this._settings.set_boolean('enable-menu-button-arrow', check.get_active());
+        }));
+        menuButtonArrowIconBoxRow.add(menuButtonArrowIconLabel);
+        menuButtonArrowIconBoxRow.add(enableArrowIconSwitch);
+        menuButtonTextFrame.add(menuButtonArrowIconBoxRow);
+
+        /*
+        * Icon Appearance Frame
+        */
+        let menuButtonIconFrame = new AM.FrameBox();
+
+        // first row
+        let menuButtonIconBoxRow = new AM.FrameBoxRow();
+        let menuButtonIconBoxLabel = new Gtk.Label({
+            label: _('Select icon for the menu button'),
+            use_markup: true,
+            xalign: 0,
+            hexpand: true
+        });
+        // create file filter and file chooser button
+        let fileFilter = new Gtk.FileFilter();
+        fileFilter.add_pixbuf_formats();
+        let fileChooserButton = new Gtk.FileChooserButton({
+            action: Gtk.FileChooserAction.OPEN,
+            title: _('Please select an image icon'),
+            filter: fileFilter
+        });
+        fileChooserButton.connect('file-set', Lang.bind(this, function(fileChooserButton) {
+            let iconFilepath = fileChooserButton.get_filename();
+            this._settings.set_string('custom-menu-button-icon', iconFilepath);
+            menuButtonIconCombo.set_active(Constants.MENU_BUTTON_ICON.Custom);
+        }));
+        fileChooserButton.set_current_folder(GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES));
+        let iconFilepath = this._settings.get_string('custom-menu-button-icon');
+        if(iconFilepath) {
+            fileChooserButton.set_filename(iconFilepath);
+        }
+
+        let menuButtonIconCombo = new Gtk.ComboBoxText({ halign:Gtk.Align.END });
+        menuButtonIconCombo.append_text(_("Arc Menu Icon"));
+        menuButtonIconCombo.append_text(_("System Icon"));
+        menuButtonIconCombo.append_text(_("Custom Icon"));
+        menuButtonIconCombo.set_active(this._settings.get_enum('menu-button-icon'));
+        menuButtonIconCombo.connect('changed', Lang.bind(this, function(widget) {
+            this._settings.set_enum('menu-button-icon', widget.get_active());
+        }));
+
+        menuButtonIconBoxRow.add(menuButtonIconBoxLabel);
+        menuButtonIconBoxRow.add(fileChooserButton);
+        menuButtonIconBoxRow.add(menuButtonIconCombo);
+        menuButtonIconFrame.add(menuButtonIconBoxRow)
+
+        // second row
+        let menuButtonIconScaleBoxRow = new AM.FrameBoxRow();
+        let iconSize = this._settings.get_double('custom-menu-button-icon-size');
+        let menuButtonIconScaleBoxLabel = new Gtk.Label({
+            label: _('Icon size\n(default is ' + Constants.DEFAULT_ICON_SIZE + ')'),
+            use_markup: true,
+            xalign: 0
+        });
+        let hscale = new Gtk.HScale({
+            adjustment: new Gtk.Adjustment({
+                lower: 1,
+                upper: 64,
+                step_increment: 1,
+                page_increment: 1,
+                page_size: 0
+            }),
+            digits: 0,
+            round_digits: 0,
+            hexpand: true,
+            value_pos: Gtk.PositionType.RIGHT
+        });
+        hscale.connect('format-value', function(scale, value) { return value.toString() + ' px'; });
+        Constants.ICON_SIZES.forEach(function(num) {
+            hscale.add_mark(num, Gtk.PositionType.BOTTOM, num.toString());
+        });
+        hscale.set_value(iconSize);
+        hscale.connect('value-changed', Lang.bind(this, function(){
+            this._settings.set_double('custom-menu-button-icon-size', hscale.get_value());
+        }));
+
+        menuButtonIconScaleBoxRow.add(menuButtonIconScaleBoxLabel);
+        menuButtonIconScaleBoxRow.add(hscale);
+        menuButtonIconFrame.add(menuButtonIconScaleBoxRow);
+
+        // add the frames to the vbox
+        vbox.add(menuButtonTextFrame)
+        vbox.add(menuButtonIconFrame);
+    }
+});
+
 /*
  * About Page
  */
 const AboutPage = new Lang.Class({
     Name: 'AboutPage',
-    Extends: ArcMenuNotebookPage,
+    Extends: AM.NotebookPage,
 
     _init: function(settings, params) {
         this.parent(_('About'), settings, params);
@@ -323,8 +501,8 @@ const AboutPage = new Lang.Class({
 
         // Create GUI elements
         // Create the image box
-        let logoPath = Me.path + '/media/logo.png'; //TODO: path your logo
-        let [imageWidth, imageHeight] = [216, 150]; //TODO: set correct image size
+        let logoPath = Me.path + Constants.ARC_MENU_LOGO.Path;
+        let [imageWidth, imageHeight] = Constants.ARC_MENU_LOGO.Size;
         let pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(logoPath, imageWidth, imageHeight);
         let arcMenuImage = new Gtk.Image({ pixbuf: pixbuf });
         let arcMenuImageBox = new Gtk.VBox({
@@ -379,23 +557,6 @@ const AboutPage = new Lang.Class({
         vbox.add(gnuSofwareLabelBox);
 
         this.add(vbox);
-    }
-});
-
-/*
- * TODO: Places Settings Page
- */
-const PlacesSettingsPage = new Lang.Class({
-    Name: 'PlacesSettingsPage',
-    Extends: ArcMenuNotebookPage,
-
-    _init: function(settings, params) {
-        this.parent(_('Places'), settings, params);
-        
-        // Container for all general settings boxes
-        let vbox = new Gtk.Box({
-            orientation: Gtk.Orientation.VERTICAL
-        });
     }
 });
 

--- a/schemas/org.gnome.shell.extensions.arc-menu.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.arc-menu.gschema.xml
@@ -97,7 +97,7 @@
       <description>File path of the custom icon for the menu button.</description>
     </key>
     <key type="d" name="custom-menu-button-icon-size">
-      <default>24</default>
+      <default>22</default>
       <summary>Size of the icon in percentage.</summary>
       <description>Size of the icon in percentage.</description>
     </key>

--- a/schemas/org.gnome.shell.extensions.arc-menu.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.arc-menu.gschema.xml
@@ -15,6 +15,21 @@
     <value value="1" nick="Center"/>
     <value value="2" nick="Right"/>
   </enum>
+  <enum id='org.gnome.shell.extensions.arc-menu.menu-button-appearance'>
+    <value value="0" nick="Icon"/>
+    <value value="1" nick="Text"/>
+    <value value="2" nick="Icon_Text"/>
+    <value value="3" nick="Text_Icon"/>
+  </enum>
+  <enum id='org.gnome.shell.extensions.arc-menu.menu-button-text'>
+    <value value="0" nick="System_Text"/>
+    <value value="1" nick="Custom_Text"/>
+  </enum>
+  <enum id='org.gnome.shell.extensions.arc-menu.menu-button-icon'>
+    <value value="0" nick="Arc_Menu_Icon"/>
+    <value value="1" nick="System_Icon"/>
+    <value value="2" nick="Custom_Icon"/>
+  </enum>
   <schema path="/org/gnome/shell/extensions/arc-menu/" id="org.gnome.shell.extensions.arc-menu">
     <key name="visible-menus" enum="org.gnome.shell.extensions.arc-menu.visible">
       <default>'ALL'</default>
@@ -48,7 +63,43 @@
     </key>
     <key name="position-in-panel" enum="org.gnome.shell.extensions.arc-menu.menu-position">
       <default>'Left'</default>
-      <summary>Position in Panel</summary>
+      <summary>The menu position in the panel</summary>
+      <description>The menu position in the panel.</description>
+    </key>
+    <key name="menu-button-appearance" enum="org.gnome.shell.extensions.arc-menu.menu-button-appearance">
+      <default>'Icon'</default>
+      <summary>Appearance of the menu button.</summary>
+      <description>Appearance of the menu button.</description>
+    </key>
+    <key name="menu-button-text" enum="org.gnome.shell.extensions.arc-menu.menu-button-text">
+      <default>'System_Text'</default>
+      <summary>Text of the menu button.</summary>
+      <description>Text of the menu button.</description>
+    </key>
+    <key type="b" name="enable-menu-button-arrow">
+      <default>true</default>
+      <summary>Enables the default menu button arrow.</summary>
+      <description>Enables the default menu button arrow.</description>
+    </key>
+    <key type="s" name="custom-menu-button-text">
+      <default>'Applications'</default>
+      <summary>Text of the menu button.</summary>
+      <description>Text of the menu button.</description>
+    </key>
+    <key name="menu-button-icon" enum="org.gnome.shell.extensions.arc-menu.menu-button-icon">
+      <default>'Arc_Menu_Icon'</default>
+      <summary>Icon of the menu button.</summary>
+      <description>Icon of the menu button.</description>
+    </key>
+    <key type="s" name="custom-menu-button-icon">
+      <default>''</default>
+      <summary>File path of the custom icon for the menu button.</summary>
+      <description>File path of the custom icon for the menu button.</description>
+    </key>
+    <key type="d" name="custom-menu-button-icon-size">
+      <default>24</default>
+      <summary>Size of the icon in percentage.</summary>
+      <description>Size of the icon in percentage.</description>
     </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
This feature (see https://github.com/LinxGem33/Arc-Menu/issues/46) allows the user to change the menu button appearance including:
 * the menu button text
 * the menu button icon
 * the size of the icon
 * enable or disable the arrow icon beside the menu button text

Sorry that this commit is so big, but to implement the menu-button-customization feature, I had to refactor the code base. I hope these changes will help us in the future to maintain a clean code base.

Last but not least, to fully complete this commit, a *icon.svg* file for the Arc Menu Icon has to be added to the directory media.

This commit introduces the following changes:
 * Move the logic for handling settings changes in controller.js, namley in the MenuSettingsController class
 * Move common constants in constants.js
 * Refactor helper.js
 * Refactor some parts in menu.js
 * Implement the basic GUI option for changing the menu button text and the menu button icon
 * Update the schema file to include the new settings options
 * Add the file am.js, which provides customized GTK GUI elements for the prefs.js file
 * Replace author lexruee with Alexander Rüedlinger

Signed-off-by: Alexander Rüedlinger <a.rueedlinger@gmail.com>