### PR TITLE
Setup a basic localization infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,56 @@
+# Basic Makefile with bits inspired by dash-to-dock
+
+UUID=arc-menu@linxgem33.com
+DEST=~/.local/share/gnome-shell/extensions/$(UUID)
+ZIP_FILE=$(UUID).zip
+POT_FILE=./po/arc-menu.pot
+TO_LOCALIZE=prefs.js menu.js
+
 JS=*.js
 CSS=*.css
 MD=*.md
 JSON=*.json
 TXT=AUTHORS COPYING
-DIRS=schemas locale media
+DIRS=schemas locale media po
+MSG_SRC=$(wildcard ./po/*.po)
 
-DEST=~/.local/share/gnome-shell/extensions/arc-menu@linxgem33.com
 
+clean:
+	rm -f ./schemas/gschemas.compiled
+	rm -rf ./build
+	rm -f $(ZIP_FILE)
+
+install: build
+	mkdir -p $(DEST)
+	cp -r ./build/* $(DEST)
+	rm -rf ./build
+	
+uninstall:
+	rm -rf $(DEST)
+
+translations: $(POT_FILE)
+	for l in $(MSG_SRC); do \
+		msgmerge -U $$l $(POT_FILE); \
+	done;
+
+potfile: $(POT_FILE)
+
+$(POT_FILE): $(TO_LOCALIZE)
+	echo $(POT_FILE)
+	xgettext --from-code=UTF-8 -k --keyword=_ --keyword=N_ --add-comments='Translators:' \
+		-o $(POT_FILE) --package-name "Arc Menu" $(TO_LOCALIZE)
+
+./po/%.mo: ./po/%.po
+	msgfmt -c $< -o $@
 
 compile:
 	glib-compile-schemas ./schemas
 
-install: compile
-	mkdir -p $(DEST)
-	cp $(JS) $(CSS) $(JSON) $(MD) $(TXT) $(DEST)
-	cp -r $(DIRS) $(DEST)
-	
-uninstall:
-	rm -rf $(DEST)
+build: translations compile
+	mkdir -p ./build
+	cp $(JS) $(CSS) $(JSON) $(MD) $(TXT) ./build
+	cp -r $(DIRS) ./build
+
+zip-file: build
+	zip -qr $(ZIP_FILE) ./build
+	rm -rf ./build

--- a/extension.js
+++ b/extension.js
@@ -49,7 +49,7 @@ let oldGetAppFromSource;
 
 // Initialize menu language translations
 function init(metadata) {
-    Convenience.initTranslations();
+    Convenience.initTranslations('arc-menu');
 }
 
 // Enable the extension

--- a/po/arc-menu.pot
+++ b/po/arc-menu.pot
@@ -1,0 +1,210 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Arc Menu package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Arc Menu\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-07-09 16:20+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: prefs.js:76
+msgid "Behaviour"
+msgstr ""
+
+#: prefs.js:85
+msgid "Disable activities hot corner"
+msgstr ""
+
+#: prefs.js:107
+msgid "Set menu hotkey"
+msgstr ""
+
+#: prefs.js:113
+msgid "Undefined"
+msgstr ""
+
+#: prefs.js:114
+msgid "Left Super Key"
+msgstr ""
+
+#: prefs.js:115
+msgid "Right Super Key"
+msgstr ""
+
+#: prefs.js:127
+msgid "Enable custom menu keybinding"
+msgstr ""
+
+#: prefs.js:134
+msgid "Syntax: <Shift>, <Ctrl>, <Alt>, <Super>"
+msgstr ""
+
+#: prefs.js:175
+msgid "Appearance"
+msgstr ""
+
+#: prefs.js:184
+msgid "Customize menu button appearance"
+msgstr ""
+
+#: prefs.js:194
+msgid "Icon"
+msgstr ""
+
+#: prefs.js:195
+msgid "Text"
+msgstr ""
+
+#: prefs.js:196
+msgid "Icon and Text"
+msgstr ""
+
+#: prefs.js:197
+msgid "Text and Icon"
+msgstr ""
+
+#: prefs.js:222
+msgid "Menu position in panel"
+msgstr ""
+
+#: prefs.js:229
+msgid "Left"
+msgstr ""
+
+#: prefs.js:232
+msgid "Center"
+msgstr ""
+
+#: prefs.js:236
+msgid "Right"
+msgstr ""
+
+#: prefs.js:279
+msgid "Button appearance"
+msgstr ""
+
+#: prefs.js:291
+msgid "Text for the menu button"
+msgstr ""
+
+#: prefs.js:297
+msgid "System text"
+msgstr ""
+
+#: prefs.js:300
+msgid "Custom text"
+msgstr ""
+
+#: prefs.js:320
+msgid "Set custom text for the menu button"
+msgstr ""
+
+#: prefs.js:340
+msgid "Enable the arrow icon beside the button text"
+msgstr ""
+
+#: prefs.js:362
+msgid "Select icon for the menu button"
+msgstr ""
+
+#: prefs.js:372
+msgid "Please select an image icon"
+msgstr ""
+
+#: prefs.js:387
+msgid "Arc Menu Icon"
+msgstr ""
+
+#: prefs.js:388
+msgid "System Icon"
+msgstr ""
+
+#: prefs.js:389
+msgid "Custom Icon"
+msgstr ""
+
+#: prefs.js:404
+msgid "Icon size"
+msgstr ""
+
+#: prefs.js:404
+msgid "default is"
+msgstr ""
+
+#: prefs.js:448
+msgid "About"
+msgstr ""
+
+#: prefs.js:477
+msgid "Arc-Menu"
+msgstr ""
+
+#: prefs.js:482
+msgid "version: "
+msgstr ""
+
+#: prefs.js:490
+msgid "Webpage"
+msgstr ""
+
+#: menu.js:130
+msgid "Activities Overview"
+msgstr ""
+
+#: menu.js:154
+msgid "Power Off"
+msgstr ""
+
+#: menu.js:179
+msgid "Log Out"
+msgstr ""
+
+#: menu.js:204
+msgid "Suspend"
+msgstr ""
+
+#: menu.js:235
+msgid "Lock"
+msgstr ""
+
+#: menu.js:263
+msgid "Back"
+msgstr ""
+
+#: menu.js:555
+msgid "Favorites"
+msgstr ""
+
+#: menu.js:721
+msgid "Applications"
+msgstr ""
+
+#: menu.js:976
+msgid "Home"
+msgstr ""
+
+#: menu.js:1041
+msgid "Type to search…"
+msgstr ""
+
+#: menu.js:1130
+msgid "Software"
+msgstr ""
+
+#: menu.js:1134
+msgid "Settings"
+msgstr ""
+
+#: menu.js:1138
+msgid "Tweak Tool"
+msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,210 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Arc Menu package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Arc Menu\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-07-09 16:09+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: prefs.js:76
+msgid "Behaviour"
+msgstr ""
+
+#: prefs.js:85
+msgid "Disable activities hot corner"
+msgstr ""
+
+#: prefs.js:107
+msgid "Set menu hotkey"
+msgstr ""
+
+#: prefs.js:113
+msgid "Undefined"
+msgstr ""
+
+#: prefs.js:114
+msgid "Left Super Key"
+msgstr ""
+
+#: prefs.js:115
+msgid "Right Super Key"
+msgstr ""
+
+#: prefs.js:127
+msgid "Enable custom menu keybinding"
+msgstr ""
+
+#: prefs.js:134
+msgid "Syntax: <Shift>, <Ctrl>, <Alt>, <Super>"
+msgstr ""
+
+#: prefs.js:175
+msgid "Appearance"
+msgstr ""
+
+#: prefs.js:184
+msgid "Customize menu button appearance"
+msgstr ""
+
+#: prefs.js:194
+msgid "Icon"
+msgstr ""
+
+#: prefs.js:195
+msgid "Text"
+msgstr ""
+
+#: prefs.js:196
+msgid "Icon and Text"
+msgstr ""
+
+#: prefs.js:197
+msgid "Text and Icon"
+msgstr ""
+
+#: prefs.js:222
+msgid "Menu position in panel"
+msgstr ""
+
+#: prefs.js:229
+msgid "Left"
+msgstr ""
+
+#: prefs.js:232
+msgid "Center"
+msgstr ""
+
+#: prefs.js:236
+msgid "Right"
+msgstr ""
+
+#: prefs.js:279
+msgid "Button appearance"
+msgstr ""
+
+#: prefs.js:291
+msgid "Text for the menu button"
+msgstr ""
+
+#: prefs.js:297
+msgid "System text"
+msgstr ""
+
+#: prefs.js:300
+msgid "Custom text"
+msgstr ""
+
+#: prefs.js:320
+msgid "Set custom text for the menu button"
+msgstr ""
+
+#: prefs.js:340
+msgid "Enable the arrow icon beside the button text"
+msgstr ""
+
+#: prefs.js:362
+msgid "Select icon for the menu button"
+msgstr ""
+
+#: prefs.js:372
+msgid "Please select an image icon"
+msgstr ""
+
+#: prefs.js:387
+msgid "Arc Menu Icon"
+msgstr ""
+
+#: prefs.js:388
+msgid "System Icon"
+msgstr ""
+
+#: prefs.js:389
+msgid "Custom Icon"
+msgstr ""
+
+#: prefs.js:404
+msgid "Icon size"
+msgstr ""
+
+#: prefs.js:404
+msgid "default is"
+msgstr ""
+
+#: prefs.js:448
+msgid "About"
+msgstr ""
+
+#: prefs.js:477
+msgid "Arc-Menu"
+msgstr ""
+
+#: prefs.js:482
+msgid "version: "
+msgstr ""
+
+#: prefs.js:490
+msgid "Webpage"
+msgstr ""
+
+#: menu.js:130
+msgid "Activities Overview"
+msgstr ""
+
+#: menu.js:154
+msgid "Power Off"
+msgstr ""
+
+#: menu.js:179
+msgid "Log Out"
+msgstr ""
+
+#: menu.js:204
+msgid "Suspend"
+msgstr ""
+
+#: menu.js:235
+msgid "Lock"
+msgstr ""
+
+#: menu.js:263
+msgid "Back"
+msgstr ""
+
+#: menu.js:555
+msgid "Favorites"
+msgstr ""
+
+#: menu.js:721
+msgid "Applications"
+msgstr ""
+
+#: menu.js:976
+msgid "Home"
+msgstr ""
+
+#: menu.js:1041
+msgid "Type to search…"
+msgstr ""
+
+#: menu.js:1130
+msgid "Software"
+msgstr ""
+
+#: menu.js:1134
+msgid "Settings"
+msgstr ""
+
+#: menu.js:1138
+msgid "Tweak Tool"
+msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,0 +1,210 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Arc Menu package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Arc Menu\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-07-09 16:09+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: prefs.js:76
+msgid "Behaviour"
+msgstr ""
+
+#: prefs.js:85
+msgid "Disable activities hot corner"
+msgstr ""
+
+#: prefs.js:107
+msgid "Set menu hotkey"
+msgstr ""
+
+#: prefs.js:113
+msgid "Undefined"
+msgstr ""
+
+#: prefs.js:114
+msgid "Left Super Key"
+msgstr ""
+
+#: prefs.js:115
+msgid "Right Super Key"
+msgstr ""
+
+#: prefs.js:127
+msgid "Enable custom menu keybinding"
+msgstr ""
+
+#: prefs.js:134
+msgid "Syntax: <Shift>, <Ctrl>, <Alt>, <Super>"
+msgstr ""
+
+#: prefs.js:175
+msgid "Appearance"
+msgstr ""
+
+#: prefs.js:184
+msgid "Customize menu button appearance"
+msgstr ""
+
+#: prefs.js:194
+msgid "Icon"
+msgstr ""
+
+#: prefs.js:195
+msgid "Text"
+msgstr ""
+
+#: prefs.js:196
+msgid "Icon and Text"
+msgstr ""
+
+#: prefs.js:197
+msgid "Text and Icon"
+msgstr ""
+
+#: prefs.js:222
+msgid "Menu position in panel"
+msgstr ""
+
+#: prefs.js:229
+msgid "Left"
+msgstr ""
+
+#: prefs.js:232
+msgid "Center"
+msgstr ""
+
+#: prefs.js:236
+msgid "Right"
+msgstr ""
+
+#: prefs.js:279
+msgid "Button appearance"
+msgstr ""
+
+#: prefs.js:291
+msgid "Text for the menu button"
+msgstr ""
+
+#: prefs.js:297
+msgid "System text"
+msgstr ""
+
+#: prefs.js:300
+msgid "Custom text"
+msgstr ""
+
+#: prefs.js:320
+msgid "Set custom text for the menu button"
+msgstr ""
+
+#: prefs.js:340
+msgid "Enable the arrow icon beside the button text"
+msgstr ""
+
+#: prefs.js:362
+msgid "Select icon for the menu button"
+msgstr ""
+
+#: prefs.js:372
+msgid "Please select an image icon"
+msgstr ""
+
+#: prefs.js:387
+msgid "Arc Menu Icon"
+msgstr ""
+
+#: prefs.js:388
+msgid "System Icon"
+msgstr ""
+
+#: prefs.js:389
+msgid "Custom Icon"
+msgstr ""
+
+#: prefs.js:404
+msgid "Icon size"
+msgstr ""
+
+#: prefs.js:404
+msgid "default is"
+msgstr ""
+
+#: prefs.js:448
+msgid "About"
+msgstr ""
+
+#: prefs.js:477
+msgid "Arc-Menu"
+msgstr ""
+
+#: prefs.js:482
+msgid "version: "
+msgstr ""
+
+#: prefs.js:490
+msgid "Webpage"
+msgstr ""
+
+#: menu.js:130
+msgid "Activities Overview"
+msgstr ""
+
+#: menu.js:154
+msgid "Power Off"
+msgstr ""
+
+#: menu.js:179
+msgid "Log Out"
+msgstr ""
+
+#: menu.js:204
+msgid "Suspend"
+msgstr ""
+
+#: menu.js:235
+msgid "Lock"
+msgstr ""
+
+#: menu.js:263
+msgid "Back"
+msgstr ""
+
+#: menu.js:555
+msgid "Favorites"
+msgstr ""
+
+#: menu.js:721
+msgid "Applications"
+msgstr ""
+
+#: menu.js:976
+msgid "Home"
+msgstr ""
+
+#: menu.js:1041
+msgid "Type to search…"
+msgstr ""
+
+#: menu.js:1130
+msgid "Software"
+msgstr ""
+
+#: menu.js:1134
+msgid "Settings"
+msgstr ""
+
+#: menu.js:1138
+msgid "Tweak Tool"
+msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -1,0 +1,210 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Arc Menu package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Arc Menu\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-07-09 16:09+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: prefs.js:76
+msgid "Behaviour"
+msgstr ""
+
+#: prefs.js:85
+msgid "Disable activities hot corner"
+msgstr ""
+
+#: prefs.js:107
+msgid "Set menu hotkey"
+msgstr ""
+
+#: prefs.js:113
+msgid "Undefined"
+msgstr ""
+
+#: prefs.js:114
+msgid "Left Super Key"
+msgstr ""
+
+#: prefs.js:115
+msgid "Right Super Key"
+msgstr ""
+
+#: prefs.js:127
+msgid "Enable custom menu keybinding"
+msgstr ""
+
+#: prefs.js:134
+msgid "Syntax: <Shift>, <Ctrl>, <Alt>, <Super>"
+msgstr ""
+
+#: prefs.js:175
+msgid "Appearance"
+msgstr ""
+
+#: prefs.js:184
+msgid "Customize menu button appearance"
+msgstr ""
+
+#: prefs.js:194
+msgid "Icon"
+msgstr ""
+
+#: prefs.js:195
+msgid "Text"
+msgstr ""
+
+#: prefs.js:196
+msgid "Icon and Text"
+msgstr ""
+
+#: prefs.js:197
+msgid "Text and Icon"
+msgstr ""
+
+#: prefs.js:222
+msgid "Menu position in panel"
+msgstr ""
+
+#: prefs.js:229
+msgid "Left"
+msgstr ""
+
+#: prefs.js:232
+msgid "Center"
+msgstr ""
+
+#: prefs.js:236
+msgid "Right"
+msgstr ""
+
+#: prefs.js:279
+msgid "Button appearance"
+msgstr ""
+
+#: prefs.js:291
+msgid "Text for the menu button"
+msgstr ""
+
+#: prefs.js:297
+msgid "System text"
+msgstr ""
+
+#: prefs.js:300
+msgid "Custom text"
+msgstr ""
+
+#: prefs.js:320
+msgid "Set custom text for the menu button"
+msgstr ""
+
+#: prefs.js:340
+msgid "Enable the arrow icon beside the button text"
+msgstr ""
+
+#: prefs.js:362
+msgid "Select icon for the menu button"
+msgstr ""
+
+#: prefs.js:372
+msgid "Please select an image icon"
+msgstr ""
+
+#: prefs.js:387
+msgid "Arc Menu Icon"
+msgstr ""
+
+#: prefs.js:388
+msgid "System Icon"
+msgstr ""
+
+#: prefs.js:389
+msgid "Custom Icon"
+msgstr ""
+
+#: prefs.js:404
+msgid "Icon size"
+msgstr ""
+
+#: prefs.js:404
+msgid "default is"
+msgstr ""
+
+#: prefs.js:448
+msgid "About"
+msgstr ""
+
+#: prefs.js:477
+msgid "Arc-Menu"
+msgstr ""
+
+#: prefs.js:482
+msgid "version: "
+msgstr ""
+
+#: prefs.js:490
+msgid "Webpage"
+msgstr ""
+
+#: menu.js:130
+msgid "Activities Overview"
+msgstr ""
+
+#: menu.js:154
+msgid "Power Off"
+msgstr ""
+
+#: menu.js:179
+msgid "Log Out"
+msgstr ""
+
+#: menu.js:204
+msgid "Suspend"
+msgstr ""
+
+#: menu.js:235
+msgid "Lock"
+msgstr ""
+
+#: menu.js:263
+msgid "Back"
+msgstr ""
+
+#: menu.js:555
+msgid "Favorites"
+msgstr ""
+
+#: menu.js:721
+msgid "Applications"
+msgstr ""
+
+#: menu.js:976
+msgid "Home"
+msgstr ""
+
+#: menu.js:1041
+msgid "Type to search…"
+msgstr ""
+
+#: menu.js:1130
+msgid "Software"
+msgstr ""
+
+#: menu.js:1134
+msgid "Settings"
+msgstr ""
+
+#: menu.js:1138
+msgid "Tweak Tool"
+msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,0 +1,210 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Arc Menu package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Arc Menu\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-07-09 16:09+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: prefs.js:76
+msgid "Behaviour"
+msgstr ""
+
+#: prefs.js:85
+msgid "Disable activities hot corner"
+msgstr ""
+
+#: prefs.js:107
+msgid "Set menu hotkey"
+msgstr ""
+
+#: prefs.js:113
+msgid "Undefined"
+msgstr ""
+
+#: prefs.js:114
+msgid "Left Super Key"
+msgstr ""
+
+#: prefs.js:115
+msgid "Right Super Key"
+msgstr ""
+
+#: prefs.js:127
+msgid "Enable custom menu keybinding"
+msgstr ""
+
+#: prefs.js:134
+msgid "Syntax: <Shift>, <Ctrl>, <Alt>, <Super>"
+msgstr ""
+
+#: prefs.js:175
+msgid "Appearance"
+msgstr ""
+
+#: prefs.js:184
+msgid "Customize menu button appearance"
+msgstr ""
+
+#: prefs.js:194
+msgid "Icon"
+msgstr ""
+
+#: prefs.js:195
+msgid "Text"
+msgstr ""
+
+#: prefs.js:196
+msgid "Icon and Text"
+msgstr ""
+
+#: prefs.js:197
+msgid "Text and Icon"
+msgstr ""
+
+#: prefs.js:222
+msgid "Menu position in panel"
+msgstr ""
+
+#: prefs.js:229
+msgid "Left"
+msgstr ""
+
+#: prefs.js:232
+msgid "Center"
+msgstr ""
+
+#: prefs.js:236
+msgid "Right"
+msgstr ""
+
+#: prefs.js:279
+msgid "Button appearance"
+msgstr ""
+
+#: prefs.js:291
+msgid "Text for the menu button"
+msgstr ""
+
+#: prefs.js:297
+msgid "System text"
+msgstr ""
+
+#: prefs.js:300
+msgid "Custom text"
+msgstr ""
+
+#: prefs.js:320
+msgid "Set custom text for the menu button"
+msgstr ""
+
+#: prefs.js:340
+msgid "Enable the arrow icon beside the button text"
+msgstr ""
+
+#: prefs.js:362
+msgid "Select icon for the menu button"
+msgstr ""
+
+#: prefs.js:372
+msgid "Please select an image icon"
+msgstr ""
+
+#: prefs.js:387
+msgid "Arc Menu Icon"
+msgstr ""
+
+#: prefs.js:388
+msgid "System Icon"
+msgstr ""
+
+#: prefs.js:389
+msgid "Custom Icon"
+msgstr ""
+
+#: prefs.js:404
+msgid "Icon size"
+msgstr ""
+
+#: prefs.js:404
+msgid "default is"
+msgstr ""
+
+#: prefs.js:448
+msgid "About"
+msgstr ""
+
+#: prefs.js:477
+msgid "Arc-Menu"
+msgstr ""
+
+#: prefs.js:482
+msgid "version: "
+msgstr ""
+
+#: prefs.js:490
+msgid "Webpage"
+msgstr ""
+
+#: menu.js:130
+msgid "Activities Overview"
+msgstr ""
+
+#: menu.js:154
+msgid "Power Off"
+msgstr ""
+
+#: menu.js:179
+msgid "Log Out"
+msgstr ""
+
+#: menu.js:204
+msgid "Suspend"
+msgstr ""
+
+#: menu.js:235
+msgid "Lock"
+msgstr ""
+
+#: menu.js:263
+msgid "Back"
+msgstr ""
+
+#: menu.js:555
+msgid "Favorites"
+msgstr ""
+
+#: menu.js:721
+msgid "Applications"
+msgstr ""
+
+#: menu.js:976
+msgid "Home"
+msgstr ""
+
+#: menu.js:1041
+msgid "Type to search…"
+msgstr ""
+
+#: menu.js:1130
+msgid "Software"
+msgstr ""
+
+#: menu.js:1134
+msgid "Settings"
+msgstr ""
+
+#: menu.js:1138
+msgid "Tweak Tool"
+msgstr ""

--- a/prefs.js
+++ b/prefs.js
@@ -401,7 +401,7 @@ const MenuButtonCustomizationWindow = new Lang.Class({
         let menuButtonIconScaleBoxRow = new AM.FrameBoxRow();
         let iconSize = this._settings.get_double('custom-menu-button-icon-size');
         let menuButtonIconScaleBoxLabel = new Gtk.Label({
-            label: _('Icon size\n(default is ' + Constants.DEFAULT_ICON_SIZE + ')'),
+            label: _('Icon size') + '\n(' + _('default is') + ' ' + Constants.DEFAULT_ICON_SIZE + ')',
             use_markup: true,
             xalign: 0
         });


### PR DESCRIPTION
This pull-request setups a basic localization infrastructure for supporting multiple languages, as requested in issue https://github.com/LinxGem33/Arc-Menu/issues/5. 

The translatable strings are contained in the file `./po/arc-menu.pot`. This file can be used to generate the po translation file for a specific language. Template Po files for some languages are found in the po directory. 

Thanks to the the adapted Makefile, we can now easily build the whole project. In summary, the Makefile supports the following make commands:
 * make potfile <=> Used to generate the potfile that contains all translatable strings of the Arc Meu project.
 * make translations <=> When the translatable strings change this command can be used to update all po files before updating translations.
 * make build <=> Builds the whole project in the subdirectory `./build`.
 * make clean <=> Deletes all build files and the `./build` directory.
 * make zip-file <=> Creates a distributable zip-file of the whole project.
 * make install <=> Installs Arc Menu in `~/.local/share/gnome-shell/extensions/arc-menu@linxgem33.com`.
 * make uninstall <=> Deletes the directory `~/.local/share/gnome-shell/extensions/arc-menu@linxgem33.com`.

Overall, this pull-request introduces the following changes:
 * extension.js: specify the domain for loading the translations
 * Makefile: adapt Makefile for creating a potfile
 * arc-menu.pot: add a basic potfile for Arc Menu
 * pref.js: fix string
 * po: add some template files for different languages

Signed-off-by: Alexander Rüedlinger <a.rueedlinger@gmail.com>