### PR TITLE
Update Makefile and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 # ignorre compiled schemas
 *.compiled
+
+# ignore genrated zip files
+*.zip
+
+# ignore compiled po files
+*.mo
+
+# ignore build directory
+build

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CSS=*.css
 MD=*.md
 JSON=*.json
 TXT=AUTHORS COPYING
-DIRS=schemas locale media po
+DIRS=schemas media po
 MSG_SRC=$(wildcard ./po/*.po)
 
 
@@ -46,10 +46,16 @@ $(POT_FILE): $(TO_LOCALIZE)
 compile:
 	glib-compile-schemas ./schemas
 
-build: translations compile
+build: translations compile $(MSG_SRC:.po=.mo)
 	mkdir -p ./build
 	cp $(JS) $(CSS) $(JSON) $(MD) $(TXT) ./build
 	cp -r $(DIRS) ./build
+	mkdir -p ./build/locale
+	for l in $(MSG_SRC:.po=.mo) ; do \
+		lf=./build/locale/`basename $$l .mo`; \
+		mkdir -p $$lf/LC_MESSAGES; \
+		cp $$l $$lf/LC_MESSAGES/arc-menu.mo; \
+	done;
 
 zip-file: build
 	zip -qr $(ZIP_FILE) ./build


### PR DESCRIPTION
This pull-request completes the previous pull-request https://github.com/LinxGem33/Arc-Menu/pull/53 :smile:.

In short, this commit introduces the following changes:
* Makefile: adapt Makefile to compile po files to mo files
* .gitignore: adapt .gitignore to ignore build files

Signed-off-by: Alexander Rüedlinger <a.rueedlinger@gmail.com>