### PR TITLE
Make the code base localization ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # ignore build directory
 build
+
+# ignore files such as de.po~
+*~

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CSS=*.css
 MD=*.md
 JSON=*.json
 TXT=AUTHORS COPYING
-DIRS=schemas media po
+DIRS=schemas media
 MSG_SRC=$(wildcard ./po/*.po)
 
 

--- a/extension.js
+++ b/extension.js
@@ -49,7 +49,7 @@ let oldGetAppFromSource;
 
 // Initialize menu language translations
 function init(metadata) {
-    Convenience.initTranslations('arc-menu');
+    Convenience.initTranslations(Me.metadata['gettext-domain']);
 }
 
 // Enable the extension

--- a/menu.js
+++ b/menu.js
@@ -81,9 +81,16 @@ const DEFAULT_DIRECTORIES = [
     GLib.UserDirectory.DIRECTORY_DOWNLOAD,
     GLib.UserDirectory.DIRECTORY_MUSIC,
     GLib.UserDirectory.DIRECTORY_PICTURES,
-    GLib.UserDirectory.DIRECTORY_VIDEOS,
-	
+    GLib.UserDirectory.DIRECTORY_VIDEOS
 ];
+const DEFAULT_DIRECTORY_NAMES = [
+    _("Documents"),
+    _("Downloads"),
+    _("Music"),
+    _("Pictures"),
+    _("Videos")
+];
+
 
 function setIconAsync(icon, gioFile, fallback_icon_name) {
   gioFile.load_contents_async(null, function(source, result) {
@@ -976,16 +983,17 @@ const ApplicationsButton = new Lang.Class({
         let placeInfo = new PlaceInfo(Gio.File.new_for_path(homePath), _("Home"));
         let placeMenuItem = new PlaceMenuItem(this, placeInfo);
         this.rightBox.add_actor(placeMenuItem.actor);
-        let dirs = DEFAULT_DIRECTORIES.slice();
-        for (let i = 0; i < dirs.length; i++) {
-            let path = GLib.get_user_special_dir(dirs[i]);
-            if (path == null || path == homePath)
-                continue;
-            let placeInfo = new PlaceInfo(Gio.File.new_for_path(path));
-            let placeMenuItem = new PlaceMenuItem(this, placeInfo);
-            this.rightBox.add_actor(placeMenuItem.actor);
+
+        for (let i=0; i < DEFAULT_DIRECTORIES.length; i++) {
+            let dir = DEFAULT_DIRECTORIES[i];
+            let name = DEFAULT_DIRECTORY_NAMES[i];
+            let path = GLib.get_user_special_dir(dir);
+            if (path !== null && path != homePath) {
+                let placeInfo = new PlaceInfo(Gio.File.new_for_path(path), name);
+                let placeMenuItem = new PlaceMenuItem(this, placeInfo);
+                this.rightBox.add_actor(placeMenuItem.actor);
+            }
         }
-	    
     },
 
     // Scroll to a specific button (menu item) in the applications scroll view

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
 "extension-id": "arc-menu",
 "uuid": "arc-menu@linxgem33.com",
 "settings-schema": "org.gnome.shell.extensions.arc-menu",
-"gettext-domain": "gnome-shell-extension-arc-menu",
+"gettext-domain": "arc-menu",
 "name": "Arc Menu",
 "description": "The new applications menu for Gnome 3.",
   "shell-version": [

--- a/prefs.js
+++ b/prefs.js
@@ -514,7 +514,7 @@ const AboutPage = new Lang.Class({
 
 // Initialize menu language translations
 function init() {
-    Convenience.initTranslations();
+    Convenience.initTranslations(Me.metadata['gettext-domain']);
 }
 
 function buildPrefsWidget() {

--- a/schemas/org.gnome.shell.extensions.arc-menu.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.arc-menu.gschema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schemalist gettext-domain="gnome-shell-extensions-arc-menu">
+<schemalist gettext-domain="arc-menu">
   <enum id='org.gnome.shell.extensions.arc-menu.visible'>
     <value value='0' nick='ALL'/>
     <value value='1' nick='APPS_ONLY'/>


### PR DESCRIPTION
To make the code base localization ready, this commit introduces the following changes:
 * .gitignore: update .gitignore so that it ignores backup files such as de.po~
 * metadata.json: set gettext-domain to "arc-menu"
 * schema file: set gettext-domain to "arc-menu"
 * Makefile: update Makefile so it does not copy the po directory to the build directory
 * prefs.js: make it localization ready
 * extension.js: make it localization ready
 * menu.js: fix missing strings for translation

Example of using the Italian language as the system language:
![schermata del 2017-07-09 20-59-38](https://user-images.githubusercontent.com/649340/27997052-f823bd20-64ef-11e7-8f5b-f42f8d6c3891.png)


PS: JavaScript is PITA! I miss strongly and statically typed programming languages like JAVA!

Signed-off-by: Alexander Rüedlinger <a.rueedlinger@gmail.com>