### PR TITLE
Fix Makefile: rebuild always the arc-menu.pot file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ translations: $(POT_FILE)
 
 potfile: $(POT_FILE)
 
-$(POT_FILE): $(TO_LOCALIZE)
+$(POT_FILE): $(TO_LOCALIZE) FORCE
 	echo $(POT_FILE)
 	xgettext --from-code=UTF-8 -k --keyword=_ --keyword=N_ --add-comments='Translators:' \
 		-o $(POT_FILE) --package-name "Arc Menu" $(TO_LOCALIZE)
@@ -60,3 +60,6 @@ build: translations compile $(MSG_SRC:.po=.mo)
 zip-file: build
 	zip -qr $(ZIP_FILE) ./build
 	rm -rf ./build
+
+.PHONY: FORCE
+FORCE:


### PR DESCRIPTION
Fix Makefile so that it always rebuilds the arc-menu.pot file. 

In order to rebuild all language files on every 'make build', the  arc-menu.pot file has always to be rebuilt. 
Thus, we use the FORCE mechanism of make: https://stackoverflow.com/questions/7643838/how-to-force-make-to-always-rebuild-a-file

Signed-off-by: Alexander Rüedlinger <a.rueedlinger@gmail.com>