### PR TITLE
Makefile: Simplify the installation of the extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,12 @@ DIRS=schemas media
 MSG_SRC=$(wildcard ./po/*.po)
 
 
+enable:
+	gnome-shell-extension-tool -e $(UUID)
+
+disable:
+	gnome-shell-extension-tool -d $(UUID)
+
 clean:
 	rm -f ./schemas/gschemas.compiled
 	rm -rf ./build

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Awaiting packagers
 
 ##
 ### Manual Installation (for testers & enthusiasts)
-Probably, the simplest way to install Arc Menu is using **git** and **make**.
-So, if you have installed git and make, you can proceed as follows.
+Probably, the simplest way to install Arc Menu is using **git**, **make** and **gnome-shell-extension-tool**.
+So, if you have installed git, make and gnome-shell-extension-tool, you can proceed as follows.
 
 1) Clone the repository via the git-clone command and change to the Arc-Menu directory:
 ```
@@ -54,9 +54,14 @@ make uninstall
 make install
 ```
 
-4) Restart the GNOME Shell with Alt + F2 and enter 'r' (without quotes).
+4) Enable or disable the extension via:
+```
+make enable
+```
 
-5) Open the gnome-tweak-tool and activate Arc-Menu.
+```
+make disable
+```
 
 
 ##


### PR DESCRIPTION
@LinxGem33 
This will be my last pull-request for today :smile:.
I just found out how we can greatly simplify the Manual Installation using `make`.

Thanks to the very handy program `gnome-shell-extension-tool`, we can easily enable and disable the extension once it is installed, without restarting the GNOME Shell. 

That is pretty cool. For more details see:
https://wiki.gnome.org/Projects/GnomeShell/Extensions

This commit introduces the following changes:
 * Makefile: add `make enable` command to enable the extension.
 * Makefile: add `make disable` command to disable the extension.
 * README.md: update the section Manual Installation

Signed-off-by: Alexander Rüedlinger <a.rueedlinger@gmail.com>