### PR TITLE
controller.js: implement method _isActivitiesButtonPresent

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -41,7 +41,6 @@ const Helper = Me.imports.helper;
     _init: function(settings, menuButton) {
         this._settings = settings;
         this._menuButton = menuButton;
-        this._activitiesButtonIsRemoved = false;
         this._activitiesButton = Main.panel.statusArea['activities'];
 
         // Create a Hot Corner Manager, a Menu Keybinder as well as a Keybinding Manager
@@ -226,21 +225,27 @@ const Helper = Me.imports.helper;
         }
     },
 
+    // Check if the activities button is present on the main panel
+    _isActivitiesButtonPresent: function () {
+        // Thanks to lestcape @github.com for the refinement of this method.
+        return (this._activitiesButton &&
+            this._activitiesButton.container &&
+            Main.panel._leftBox.contains(this._activitiesButton.container));
+    },
+
     // Remove the activities button from the main panel
     _removeActivitiesButtonFromMainPanel: function() {
-        if (!this._activitiesButtonIsRemoved) {
+        if (this._isActivitiesButtonPresent()) {
             Main.panel._leftBox.remove_child(this._activitiesButton.container);
-            this._activitiesButtonIsRemoved = true;
         }
     },
 
     // Add or restore the activities button on the main panel
     _addActivitiesButtonToMainPanel: function() {
-        if (this._activitiesButtonIsRemoved) {
+        if (!this._isActivitiesButtonPresent()) {
             // Retsore the activities button at the default position
             Main.panel._leftBox.add_child(this._activitiesButton.container);
             Main.panel._leftBox.set_child_at_index(this._activitiesButton.container, 0);
-            this._activitiesButtonIsRemoved = false;
         }
     },
 


### PR DESCRIPTION
This pull-request refactors controller.js. 

It introduces the method _isActivitiesButtonPresent which checks if the Activities Button is present on the main panel. In short, it is used to check if we can add/remove the Activities Button to the main panel.
Thanks to @lestcape for the refinement of this method and the bug report.

I tested it on my virtual machines:
 * Ubuntu Gnome 16.04 LTS
 * Ubuntu Gnome 17.04
 * Debian Stretch
 * Debian Sid
 * Arch Linux