### PR TITLE
remove fixes for the adapta theme

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -179,10 +179,6 @@ const Helper = Me.imports.helper;
         let menuButtonWidget = this._menuButton.getWidget();
         let stIcon = menuButtonWidget.getPanelIcon();
 
-        if (stIcon.has_style_class_name('popup-menu-icon')) {
-            stIcon.remove_style_class_name('popup-menu-icon');
-        }
-
         switch (this._settings.get_enum('menu-button-icon')) {
             case Constants.MENU_BUTTON_ICON.Custom:
                 if (GLib.file_test(iconFilepath, GLib.FileTest.EXISTS)) {
@@ -198,7 +194,6 @@ const Helper = Me.imports.helper;
             case Constants.MENU_BUTTON_ICON.System:
             default:
                 stIcon.set_icon_name('start-here-symbolic');
-                stIcon.add_style_class_name('popup-menu-icon');
         }
     },
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -36,11 +36,3 @@
 .apps-menu:rtl {
     padding-left: 0.1875em;
 }
-
-/* adapta fixes */
-#panelApplications StIcon, #panelApplications:hover StIcon, #panelApplications:focus StIcon, #panelApplications:active StIcon, #panelApplications:checked StIcon { color: inherit; }
-
-#panelApplications StIcon.popup-menu-icon { background-image: initial; }
-
-#panelApplications:hover StIcon.popup-menu-icon, #panelApplications:focus StIcon.popup-menu-icon, #panelApplications:active StIcon.popup-menu-icon, #panelApplications:checked StIcon.popup-menu-icon { background-image: initial; }
-


### PR DESCRIPTION
As discussed with **@LinxGem33**, we don't fix theme issues in our JS/CSS code since this would introduce workarounds and fishy code in our code base.

In a nutshell, this commit basically reverts the pull request: https://github.com/LinxGem33/Arc-Menu/pull/87

Signed-off-by: Alexander Rüedlinger <a.rueedlinger@gmail.com>