### PR TITLE
menu.js: remove dead code

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -813,9 +813,6 @@ const ApplicationsButton = new Lang.Class({
                 this.reloadFlag = true;
             }
         }));
-        this._panelBoxChangedId = Main.layoutManager.connect('panel-box-changed', Lang.bind(this, function() {
-            container.queue_relayout();
-        }));
         Main.panel.actor.connect('notify::height', Lang.bind(this,
             function() {
                 this._redisplay();
@@ -842,7 +839,6 @@ const ApplicationsButton = new Lang.Class({
     _onDestroy: function() {
         Main.overview.disconnect(this._showingId);
         Main.overview.disconnect(this._hidingId);
-        Main.layoutManager.disconnect(this._panelBoxChangedId);
         appSys.disconnect(this._installedChangedId);
     },
 


### PR DESCRIPTION
This pull-request removes dead code in menu.js (see class ApplicationsButton),
which uses some dead from the upstream GNOME apps-menu.

For more details see the bug reports on bugzilla.gnome.org:
 * https://bugzilla.gnome.org/show_bug.cgi?id=785200
 * https://bugzilla.gnome.org/show_bug.cgi?id=785202

Signed-off-by: Alexander Rüedlinger <a.rueedlinger@gmail.com>