### PR TITLE
menu.js: eliminate unnecessary code in class ApplicationMenuItem

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -389,7 +389,6 @@ const ApplicationMenuItem = new Lang.Class({
         this.isDraggableApp = true;
         this._draggable.connect('drag-begin', Lang.bind(this,
             function () {
-                this._removeMenuTimeout();
                 Main.overview.beginItemDrag(this);
             }));
         this._draggable.connect('drag-cancelled', Lang.bind(this,


### PR DESCRIPTION
This pull-request eliminates lot of unnecessary code in menu.js.

In short, it removes some code in the class ApplicationMenuItem. I could not figure out what the removed code was supposed to accomplish and I could not find any difference in the behaviour of the menu.

As a reference for the code elimination I used the upstream implementation of ApplicationMenuItem in the [gnome-apps extension](https://github.com/GNOME/gnome-shell-extensions/blob/master/extensions/apps-menu/extension.js) as well as the class PopupBaseMenuItem from the [gnome-shell code base](https://github.com/GNOME/gnome-shell/blob/master/js/ui/popupMenu.js).

Signed-off-by: Alexander Rüedlinger <a.rueedlinger@gmail.com>