### PR TITLE
prefs.js: show GPL2 info text on the about page

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -503,12 +503,14 @@ const AboutPage = new Lang.Class({
             justify: Gtk.Justification.CENTER,
             expand: true
         });
-        let gnuSofwareLabelBox = new Gtk.VBox({});
-        gnuSofwareLabelBox.pack_end(gnuSofwareLabel,false, false, 0);
+        let gnuSofwareLabelBox = new Gtk.Box({
+            orientation: Gtk.Orientation.VERTICAL
+        });
+        gnuSofwareLabelBox.add(gnuSofwareLabel,false, false, 0);
 
         this.add(arcMenuImageBox);
         this.add(arcMenuInfoBox);
-        this.add(gnuSofwareLabel);
+        this.add(gnuSofwareLabelBox);
     }
 });
 

--- a/prefs.js
+++ b/prefs.js
@@ -506,7 +506,7 @@ const AboutPage = new Lang.Class({
         let gnuSofwareLabelBox = new Gtk.Box({
             orientation: Gtk.Orientation.VERTICAL
         });
-        gnuSofwareLabelBox.add(gnuSofwareLabel,false, false, 0);
+        gnuSofwareLabelBox.add(gnuSofwareLabel);
 
         this.add(arcMenuImageBox);
         this.add(arcMenuInfoBox);


### PR DESCRIPTION
As the title says: prefs.js: show GPL2 info text on the about page :-)