### PR TITLE
prefjs.js & prefsWidgets.js: refactor Notebook, NotebookPage, and ArcMenuPreferencesWidget

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -53,13 +53,13 @@ const ArcMenuPreferencesWidget= new GObject.Class({
         let notebook = new PW.Notebook();
         
         let behaviourSettingsPage = new BehaviourSettingsPage(this.settings);
-        notebook.append_page(behaviourSettingsPage, behaviourSettingsPage.title);
+        notebook.append_page(behaviourSettingsPage);
 
         let appearancePage = new AppearanceSettingsPage(this.settings);
-        notebook.append_page(appearancePage, appearancePage.title);
+        notebook.append_page(appearancePage);
 
         let aboutPage = new AboutPage(this.settings);
-        notebook.append_page(aboutPage, aboutPage.title);
+        notebook.append_page(aboutPage);
 
         this.add(notebook);
     }

--- a/prefsWidgets.js
+++ b/prefsWidgets.js
@@ -47,6 +47,14 @@ const Notebook = new GObject.Class({
             margin_left: 6,
             margin_right: 6
         });
+    },
+
+    append_page: function(notebookPage) {
+        Gtk.Notebook.prototype.append_page.call(
+            this,
+            notebookPage,
+            notebookPage.getTitleLabel()
+        );
     }
 });
 
@@ -65,11 +73,15 @@ const NotebookPage = new GObject.Class({
             spacing: 20,
             homogeneous: false
         });
-        this.title = new Gtk.Label({
+        this._title = new Gtk.Label({
             label: "<b>" + title + "</b>",
             use_markup: true,
             xalign: 0
         });
+    },
+
+    getTitleLabel: function() {
+        return this._title;
     }
 });
 


### PR DESCRIPTION
Another refactoring pull-request :smile:.

In summary, this pull-request introduces the following changes:
 * prefsWidgets.js: add the public method getTitleLabel to the class NotebookPage
 * prefsWidgets.js: make the property title of the class NotebookPage private by using the prefix _
 * prefsWidgets.js: override the inherited public method Gtk.Notebook.append_page in class Notebook
                    to avoid boilerplate code
 * prefs.js: adapt the class ArcMenuPreferencesWidget to use the new internal API

Signed-off-by: Alexander Rüedlinger <a.rueedlinger@gmail.com>