### PR TITLE
Refactor metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,8 +7,6 @@
     "description": "The new applications menu for Gnome 3.",
     "version": -1,
     "shell-version": [
-        "3.14",
-        "3.16",
         "3.18",
         "3.20",
         "3.22",

--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
     "gettext-domain": "arc-menu",
     "name": "Arc Menu",
     "description": "The new applications menu for Gnome 3.",
+    "version": -1,
     "shell-version": [
         "3.14",
         "3.16",

--- a/metadata.json
+++ b/metadata.json
@@ -1,17 +1,17 @@
 {
-"extension-id": "arc-menu",
-"uuid": "arc-menu@linxgem33.com",
-"settings-schema": "org.gnome.shell.extensions.arc-menu",
-"gettext-domain": "arc-menu",
-"name": "Arc Menu",
-"description": "The new applications menu for Gnome 3.",
-  "shell-version": [
-    "3.14", 
-    "3.16", 
-    "3.18", 
-    "3.20", 
-    "3.22", 
-    "3.24"
-  ],
-"url": "https://github.com/LinxGem33/Arc-Menu.git"
+    "extension-id": "arc-menu",
+    "uuid": "arc-menu@linxgem33.com",
+    "settings-schema": "org.gnome.shell.extensions.arc-menu",
+    "gettext-domain": "arc-menu",
+    "name": "Arc Menu",
+    "description": "The new applications menu for Gnome 3.",
+    "shell-version": [
+        "3.14",
+        "3.16",
+        "3.18",
+        "3.20",
+        "3.22",
+        "3.24"
+    ],
+    "url": "https://github.com/LinxGem33/Arc-Menu.git"
 }


### PR DESCRIPTION
In summary:
 * metadata.json: reformat json
 * metadata.json: add a default version of -1
 * metadata.json: drop support for 3.14 and 3.16

The use of a default version of -1 is really helpful for versioning development builds with sed and git hashes.  I assume that extensions.gnome.org will always override the version number.