### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DEST=~/.local/share/gnome-shell/extensions/$(UUID)
 ZIP_FILE=$(UUID).zip
 POT_FILE=./po/arc-menu.pot
 TO_LOCALIZE=prefs.js menu.js
+VERSION=$(shell git log --pretty=format:'%h' -n 1)
 
 JS=*.js
 CSS=*.css
@@ -62,6 +63,7 @@ build: translations compile $(MSG_SRC:.po=.mo)
 		mkdir -p $$lf/LC_MESSAGES; \
 		cp $$l $$lf/LC_MESSAGES/arc-menu.mo; \
 	done;
+	sed -i 's/"version": -1/"version": "$(VERSION)"/'  build/metadata.json;
 
 zip-file: build
 	zip -qr $(ZIP_FILE) ./build

--- a/prefs.js
+++ b/prefs.js
@@ -449,7 +449,7 @@ const AboutPage = new Lang.Class({
         this.settings = settings;
 
         // Use meta information from metadata.json
-        let releaseVersion = Me.metadata['version'] || 'bleeding-edge ;-)';
+        let releaseVersion = Me.metadata['version'] || 'unknown';
         let projectName = Me.metadata['name'];
         let projectDescription = Me.metadata['description'];
         let projectUrl = Me.metadata['url'];


### PR DESCRIPTION
This updated Makefile automatically versions development builds using sed and a pretty git hash.
Moreover, the file prefs.js is updated. The about page will show the string unknown if the metadata.json does not contain a version number.