### PR TITLE
Makefile: add jshint and test targets

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -78,5 +78,5 @@
     "white"         : false,    // true: Check against strict whitespace and indentation rules
 
     // Custom Globals
-    "predef"        : [ "global", "log", "logError", "print", "printerr", "imports", "ARGV", "pkg", "_", "C_", "N_" ]
+    "predef"        : [ "global", "log", "logError", "print", "printerr", "imports", "ARGV", "pkg", "C_", "N_" ]
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,82 @@
+{
+    "maxerr"        : 100,       // {int} Maximum error before stopping
+
+    // Enforcing
+    "bitwise"       : false,    // true: Prohibit bitwise operators (&, |, ^, etc.)
+    "camelcase"     : false,    // true: Identifiers must be in camelCase
+    "curly"         : true,    // true: Require {} for every new block or scope
+    "eqeqeq"        : true,     // true: Require triple equals (===) for comparison
+    "forin"         : false,    // true: Require filtering for..in loops with obj.hasOwnProperty()
+    "immed"         : false,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
+    "indent"        : 4,        // {int} Number of spaces to use for indentation
+    "latedef"       : "nofunc", // true: Require variables/functions to be defined before being used
+    "newcap"        : true,     // true: Require capitalization of all constructor functions e.g. `new F()`
+    "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
+    "noempty"       : true,     // true: Prohibit use of empty blocks
+    "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
+    "plusplus"      : false,    // true: Prohibit use of `++` & `--`
+    "quotmark"      : false,    // Quotation mark consistency:
+                                //   false    : do nothing (default)
+                                //   true     : ensure whatever is used is consistent
+                                //   "single" : require single quotes
+                                //   "double" : require double quotes
+    "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
+    "unused"        : false,    // true: Require all defined variables be used
+    "strict"        : false,    // true: Requires all functions run in ES5 Strict Mode
+    "trailing"      : true,     // true: Prohibit trailing whitespaces
+    "maxparams"     : false,    // {int} Max number of formal params allowed per function
+    "maxdepth"      : false,    // {int} Max depth of nested blocks (within functions)
+    "maxstatements" : false,    // {int} Max number statements per function
+    "maxcomplexity" : false,    // {int} Max cyclomatic complexity per function
+    "maxlen"        : false,    // {int} Max number of characters per line
+
+    // Relaxing
+    "asi"           : false,     // true: Tolerate Automatic Semicolon Insertion (no semicolons)
+    "boss"          : false,     // true: Tolerate assignments where comparisons would be expected
+    "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
+    "eqnull"        : false,     // true: Tolerate use of `== null`
+    "esnext"        : true,      // true: Allow ES.next (ES6) syntax (ex: `const`)
+    "moz"           : true,      // true: Allow Mozilla specific syntax (extends and overrides esnext features)
+                                 // (ex: `for each`, multiple try/catch, function expression…)
+    "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`
+    "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs
+    "funcscope"     : false,     // true: Tolerate defining variables inside control statements"
+    "globalstrict"  : false,     // true: Allow global "use strict" (also enables 'strict')
+    "iterator"      : false,     // true: Tolerate using the `__iterator__` property
+    "lastsemic"     : false,     // true: Tolerate omitting a semicolon for the last statement of a 1-line block
+    "laxbreak"      : true,      // true: Tolerate possibly unsafe line breakings
+    "laxcomma"      : false,     // true: Tolerate comma-first style coding
+    "loopfunc"      : false,     // true: Tolerate functions being defined in loops
+    "multistr"      : true,      // true: Tolerate multi-line strings
+    "proto"         : false,     // true: Tolerate using the `__proto__` property
+    "scripturl"     : false,     // true: Tolerate script-targeted URLs
+    "smarttabs"     : false,     // true: Tolerate mixed tabs/spaces when used for alignment
+    "shadow"        : false,     // true: Allows re-define variables later in code e.g. `var x=1; x=2;`
+    "sub"           : false,     // true: Tolerate using `[]` notation when it can still be expressed in dot notation
+    "supernew"      : false,     // true: Tolerate `new function () { ... };` and `new Object;`
+    "validthis"     : false,     // true: Tolerate using this in a non-constructor function
+
+    // Environments
+    "browser"       : false,    // Web Browser (window, document, etc)
+    "couch"         : false,    // CouchDB
+    "devel"         : false,    // Development/debugging (alert, confirm, etc)
+    "dojo"          : false,    // Dojo Toolkit
+    "jquery"        : false,    // jQuery
+    "mootools"      : false,    // MooTools
+    "node"          : false,    // Node.js
+    "nonstandard"   : false,    // Widely adopted globals (escape, unescape, etc)
+    "prototypejs"   : false,    // Prototype and Scriptaculous
+    "rhino"         : false,    // Rhino
+    "worker"        : false,    // Web Workers
+    "wsh"           : false,    // Windows Scripting Host
+    "yui"           : false,    // Yahoo User Interface
+
+    // Legacy
+    "nomen"         : false,    // true: Prohibit dangling `_` in variables
+    "onevar"        : false,    // true: Allow only one `var` statement per function
+    "passfail"      : false,    // true: Stop on first error
+    "white"         : false,    // true: Check against strict whitespace and indentation rules
+
+    // Custom Globals
+    "predef"        : [ "global", "log", "logError", "print", "printerr", "imports", "ARGV", "pkg", "_", "C_", "N_" ]
+}

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ TXT=AUTHORS COPYING
 DIRS=schemas media
 MSG_SRC=$(wildcard ./po/*.po)
 
+all: build
 
 enable:
 	gnome-shell-extension-tool -e $(UUID)
@@ -26,6 +27,11 @@ clean:
 	rm -f ./schemas/gschemas.compiled
 	rm -rf ./build
 	rm -f $(ZIP_FILE)
+
+jshint:
+	jshint $(JS)
+
+test: jshint
 
 install: build
 	mkdir -p $(DEST)


### PR DESCRIPTION
In short:
 * Add jshint and test (for possible future tests) targets for checking the js files using jshint. 
 * And also add the missing `all` target.

If you have installed jshint, you can simply run `make jshint` for checking syntax or coding style errors. You can also run `jshint somefile.js` for checking individual files.

Currently, jshint will print lot of errors since the code base is a mess regarding the JS coding style :-).
So the goal would be to reduce them to a sane amount.