### PR TITLE
menu.js: add _onKeyPressEvent handler to ApplicationMenuItem

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -402,6 +402,17 @@ const ApplicationMenuItem = new Lang.Class({
             }));
     },
 
+    _onKeyPressEvent: function (actor, event) {
+        let symbol = event.get_key_symbol();
+        if (symbol == Clutter.KEY_space ||
+            symbol == Clutter.KEY_Return ||
+            symbol == Clutter.KEY_KP_Enter) {
+            this.activate(event);
+            return Clutter.EVENT_STOP;
+        }
+        return Clutter.EVENT_PROPAGATE;
+    },
+
     get_app_id: function() {
         return this._app.get_id();
     },


### PR DESCRIPTION
In the pull-request #104, I made a stupid mistake :-/ and deleted the `_onKeyPressEvent` handler in the class ApplicationMenuItem. For this reason the key KEY_KP_Enter is currently not handled. That was probably also the reason for the merge conflict. Shame on me :disappointed:.

This commit fixes that and backports the _onKeyPressEvent handler from this commit here: https://github.com/LinxGem33/Arc-Menu/pull/103/commits/e6a198cb5c4291d0e4beb5036cc1c37536d7c63d