### PR TITLE
Update makefile: add help target and system-wide installation support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,22 @@
 # Basic Makefile with bits inspired by dash-to-dock
 
 UUID=arc-menu@linxgem33.com
-DEST=~/.local/share/gnome-shell/extensions/$(UUID)
 ZIP_FILE=$(UUID).zip
-POT_FILE=./po/arc-menu.pot
+POT_FILEPATH=./po/arc-menu.pot
+MO_FILE=arc-menu.mo
+GSCHEMA_FILE=org.gnome.shell.extensions.arc-menu.gschema.xml
+
 TO_LOCALIZE=prefs.js menu.js
 VERSION=$(shell git log --pretty=format:'%h' -n 1)
+
+ifeq ($(strip $(INSTALL)),system) # check if INSTALL == system
+	INSTALL_TYPE=system
+	SHARE_PREFIX=$(DESTDIR)/usr/share
+	INSTALL_BASE=$(SHARE_PREFIX)/gnome-shell/extensions
+else
+	INSTALL_TYPE=local
+	INSTALL_BASE=~/.local/share/gnome-shell/extensions
+endif
 
 JS=*.js
 CSS=*.css
@@ -47,24 +58,33 @@ jshint:
 test: jshint
 
 install: build
-	mkdir -p $(DEST)
-	cp -r ./build/* $(DEST)
+	mkdir -p $(INSTALL_BASE)/$(UUID)
+	cp -r ./build/* $(INSTALL_BASE)/$(UUID)
+ifeq ($(INSTALL_TYPE),system)
+	mkdir -p $(SHARE_PREFIX)/glib-2.0/schemas $(SHARE_PREFIX)/locale
+	cp -r ./schemas/$(GSCHEMA_FILE) $(SHARE_PREFIX)/glib-2.0/schemas
+	cp -r ./build/locale/* $(SHARE_PREFIX)/locale
+endif
 	rm -rf ./build
-	
-uninstall:
-	rm -rf $(DEST)
 
-translations: $(POT_FILE)
+uninstall:
+	rm -rf $(INSTALL_BASE)/$(UUID)
+ifeq ($(INSTALL_TYPE),system)
+	rm -f $(SHARE_PREFIX)/glib-2.0/schemas/$(GSCHEMA_FILE)
+	find $(SHARE_PREFIX)/locale -name $(MO_FILE) -type f -delete
+endif
+
+translations: $(POT_FILEPATH)
 	for l in $(MSG_SRC); do \
-		msgmerge -U $$l $(POT_FILE); \
+		msgmerge -U $$l $(POT_FILEPATH); \
 	done;
 
-potfile: $(POT_FILE)
+potfile: $(POT_FILEPATH)
 
-$(POT_FILE): $(TO_LOCALIZE) FORCE
-	echo $(POT_FILE)
+$(POT_FILEPATH): $(TO_LOCALIZE) FORCE
+	echo $(POT_FILEPATH)
 	xgettext --from-code=UTF-8 -k --keyword=_ --keyword=N_ --add-comments='Translators:' \
-		-o $(POT_FILE) --package-name "Arc Menu" $(TO_LOCALIZE)
+		-o $(POT_FILEPATH) --package-name "Arc Menu" $(TO_LOCALIZE)
 
 ./po/%.mo: ./po/%.po
 	msgfmt -c $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,20 @@ TXT=AUTHORS COPYING
 DIRS=schemas media
 MSG_SRC=$(wildcard ./po/*.po)
 
+
 all: build
+
+help:
+	@echo "Usage: make [help | all | clean | install | jshint | compile | enable | disable]"
+	@echo ""
+	@echo "all          build the project and create the build directory"
+	@echo "clean        delete the build directory"
+	@echo "install      install the extension"
+	@echo "uninstall    uninstall the extension"
+	@echo "enable       enable the extension"
+	@echo "disable      disable the extension"
+	@echo "jshint       run jshint"
+	@echo "compile      compile the gschema xml file"
 
 enable:
 	gnome-shell-extension-tool -e $(UUID)


### PR DESCRIPTION
This pull-request updates the Makefile as follows:
 * add help target that shows some helpful information how to use the Makefile
 * add support for system-wide installation

**Remark:** 
Per default the Makefile will install the extension locally (~/.local/...). If the argument INSTALL is passed the makefile will install the extension either locally or system-wide.

**Examples:**
_Install and uninstall locally:_
```
make install
make install INSTALL=local
```
```
make uninstall
make uninstall INSTALL=local
```

_Install and uninstall system-wide (needs sudo):_
```
make install INSTALL=system
```
```
make uninstall INSTALL=system
```

_Show help message:_
```
make help
```