### PR TITLE
Update Makefile to make it easier to build a Arch package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifeq ($(GIT_LAST_TAG), GIT_HEAD)
 	VERSION=$(subst v,,$(LAST_RELEASE))
 	VSTRING=$(LAST_RELEASE)
 else
-	VERSION=$(shell git log --pretty=format:'%h' -n 1)
+	VERSION=$(shell git rev-parse --short HEAD)
 	VSTRING=$(VERSION)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,25 @@
 # Basic Makefile with bits inspired by dash-to-dock
 
 UUID=arc-menu@linxgem33.com
-ZIP_FILE=$(UUID).zip
 POT_FILEPATH=./po/arc-menu.pot
 MO_FILE=arc-menu.mo
 GSCHEMA_FILE=org.gnome.shell.extensions.arc-menu.gschema.xml
-
 TO_LOCALIZE=prefs.js menu.js
-VERSION=$(shell git log --pretty=format:'%h' -n 1)
+
+GIT_HEAD=$(shell git rev-parse HEAD)
+GIT_LAST_TAG=$(shell git rev-list --tags --max-count=1)
+LAST_RELEASE=$(shell git describe --tags $(GIT_LAST_TAG))
+
+# define VERSION and VSTRING
+ifeq ($(GIT_LAST_TAG), GIT_HEAD)
+	VERSION=$(subst v,,$(LAST_RELEASE))
+	VSTRING=$(LAST_RELEASE)
+else
+	VERSION=$(shell git log --pretty=format:'%h' -n 1)
+	VSTRING=$(VERSION)
+endif
+
+ZIP_FILE=$(UUID)_$(VSTRING).zip
 
 ifeq ($(strip $(INSTALL)),system) # check if INSTALL == system
 	INSTALL_TYPE=system
@@ -50,7 +62,7 @@ disable:
 clean:
 	rm -f ./schemas/gschemas.compiled
 	rm -rf ./build
-	rm -f $(ZIP_FILE)
+	rm -f ./$(UUID)*.zip
 
 jshint:
 	jshint $(JS)

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ help:
 	@echo "compile      compile the gschema xml file"
 
 enable:
-	gnome-shell-extension-tool -e $(UUID)
+	-gnome-shell-extension-tool -e $(UUID)
 
 disable:
-	gnome-shell-extension-tool -d $(UUID)
+	-gnome-shell-extension-tool -d $(UUID)
 
 clean:
 	rm -f ./schemas/gschemas.compiled

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ GSCHEMA_FILE=org.gnome.shell.extensions.arc-menu.gschema.xml
 TO_LOCALIZE=prefs.js menu.js
 
 GIT_HEAD=$(shell git rev-parse HEAD)
-GIT_LAST_TAG=$(shell git rev-list --tags --max-count=1)
-LAST_RELEASE=$(shell git describe --tags $(GIT_LAST_TAG))
+LAST_RELEASE=$(shell git describe --abbrev=0 --tags --match v[0-9]*)
+GIT_LAST_TAG=$(shell git show-ref -s $(LAST_RELEASE))
 
 # define VERSION and VSTRING
 ifeq ($(GIT_LAST_TAG), GIT_HEAD)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ MSG_SRC=$(wildcard ./po/*.po)
 all: build
 
 help:
-	@echo "Usage: make [help | all | clean | install | jshint | compile | enable | disable]"
+	@echo "Usage: make [help | all | clean | install | jshint | compile |"
+	@echo "             enable | disable | zip-file]"
 	@echo ""
 	@echo "all          build the project and create the build directory"
 	@echo "clean        delete the build directory"
@@ -52,6 +53,7 @@ help:
 	@echo "disable      disable the extension"
 	@echo "jshint       run jshint"
 	@echo "compile      compile the gschema xml file"
+	@echo "zip-file     create a deployable zip file"
 
 enable:
 	-gnome-shell-extension-tool -e $(UUID)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LAST_RELEASE=$(shell git describe --abbrev=0 --tags --match v[0-9]*)
 GIT_LAST_TAG=$(shell git show-ref -s $(LAST_RELEASE))
 
 # define VERSION and VSTRING
-ifeq ($(GIT_LAST_TAG), GIT_HEAD)
+ifeq ($(GIT_LAST_TAG),$(GIT_HEAD))
 	VERSION=$(subst v,,$(LAST_RELEASE))
 	VSTRING=$(LAST_RELEASE)
 else


### PR DESCRIPTION
This pull-request makes the Makefile ready for using the Arch Linux package here:
https://github.com/lexruee/gnome-shell-extension-arc-menu-arch

The changes in short are:
 * Improve versioning for zip files and manual Arc-Menu installations
 * Ignore potential errors in enable/disable targets
 * Update output of the help target

After this pull-request we could think about resyncing the master branch with the dev branch. 