### PR TITLE
Update Makefile to make it easier for Debian packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ clean:
 	rm -rf ./build
 	rm -f ./$(UUID)*.zip
 	rm -f ./$(UUID)*.tar.gz
+	rm -f MD5SUMS SHA1SUMS SHA256SUMS SHA512SUMS
 
 jshint:
 	jshint $(JS)
@@ -122,11 +123,19 @@ zip-file: build
 	mv ./build ./Arc-Menu-$(VSTRING)
 	zip -qr $(UUID)_$(VSTRING).zip Arc-Menu-$(VSTRING)
 	rm -rf ./Arc-Menu-$(VSTRING)
+	$(MAKE) _checksums ARCHIVE_FILE=*.zip
 
 tgz-file: build
 	mv ./build ./Arc-Menu-$(VSTRING)
 	tar -zcf $(UUID)_$(VSTRING).tar.gz Arc-Menu-$(VSTRING)
 	rm -rf ./Arc-Menu-$(VSTRING)
+	$(MAKE) _checksums ARCHIVE_FILE=*.tar.gz
+
+_checksums:
+	md5sum $(ARCHIVE_FILE) >> MD5SUMS
+	sha1sum $(ARCHIVE_FILE) >> SHA1SUMS
+	sha256sum $(ARCHIVE_FILE) >> SHA256SUMS
+	sha512sum $(ARCHIVE_FILE) >> SHA512SUMS
 
 .PHONY: FORCE
 FORCE:

--- a/Makefile
+++ b/Makefile
@@ -119,12 +119,14 @@ build: translations compile $(MSG_SRC:.po=.mo)
 	sed -i 's/"version": -1/"version": "$(VERSION)"/'  build/metadata.json;
 
 zip-file: build
-	zip -qr $(UUID)_$(VSTRING).zip ./build
-	rm -rf ./build
+	mv ./build ./Arc-Menu-$(VSTRING)
+	zip -qr $(UUID)_$(VSTRING).zip Arc-Menu-$(VSTRING)
+	rm -rf ./Arc-Menu-$(VSTRING)
 
 tgz-file: build
-	tar -zcf $(UUID)_$(VSTRING).tar.gz ./build
-	rm -rf ./build
+	mv ./build ./Arc-Menu-$(VSTRING)
+	tar -zcf $(UUID)_$(VSTRING).tar.gz Arc-Menu-$(VSTRING)
+	rm -rf ./Arc-Menu-$(VSTRING)
 
 .PHONY: FORCE
 FORCE:

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,6 @@ else
 	VSTRING=$(VERSION)
 endif
 
-ZIP_FILE=$(UUID)_$(VSTRING).zip
-
 ifeq ($(strip $(INSTALL)),system) # check if INSTALL == system
 	INSTALL_TYPE=system
 	SHARE_PREFIX=$(DESTDIR)/usr/share
@@ -54,6 +52,7 @@ help:
 	@echo "jshint       run jshint"
 	@echo "compile      compile the gschema xml file"
 	@echo "zip-file     create a deployable zip file"
+	@echo "tgz-file     create a tar.gz file"
 
 enable:
 	-gnome-shell-extension-tool -e $(UUID)
@@ -65,6 +64,7 @@ clean:
 	rm -f ./schemas/gschemas.compiled
 	rm -rf ./build
 	rm -f ./$(UUID)*.zip
+	rm -f ./$(UUID)*.tar.gz
 
 jshint:
 	jshint $(JS)
@@ -119,7 +119,11 @@ build: translations compile $(MSG_SRC:.po=.mo)
 	sed -i 's/"version": -1/"version": "$(VERSION)"/'  build/metadata.json;
 
 zip-file: build
-	zip -qr $(ZIP_FILE) ./build
+	zip -qr $(UUID)_$(VSTRING).zip ./build
+	rm -rf ./build
+
+tgz-file: build
+	tar -zcf $(UUID)_$(VSTRING).tar.gz ./build
 	rm -rf ./build
 
 .PHONY: FORCE


### PR DESCRIPTION
This pull-request updates the Makefile to make it easier for Debian packaging (at least I hope so :-)). 

The pull-request introduces the following changes to the Makefile:
 * add target tgz-file to create tar.gz files
 * create checksums when invoking the targets zip-file/tgz-file (MD5, SHA1, SHA256, SHA512) 