### PR TITLE
Fix keybinding-lockscreen bug (#95)

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -170,7 +170,7 @@ const KeybindingManager = new Lang.Class({
     destroy: function() {
         let keyIter = this._keybindings.keys();
         for (let i = 0; i < this._keybindings.size; i++) {
-	        let keybindingNameKey = keyIter.next();
+	        let keybindingNameKey = keyIter.next().value;
 	        this.unbind(keybindingNameKey);
         }
     }


### PR DESCRIPTION
This pull request fixes the described bug in #95. In short, I tested this fix on Fedora 26 as well as on Ubuntu 17.10.

Shame on me! The bug was just a stupid typo (see 88b72c2) that I introduced due to lack of sleep :-). Next time I'll write tests to avoid that. 

@archqob @daniel-wtd
Can you please test this pull request and report back if it solves your issue? Thanks in advance :smiley:.