### PR TITLE
GNOME-Shell 3.25/26: Fix JS warnings (#141)

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -20,10 +20,10 @@
  */
 
 // Common constants that are used in this extension
-const EMPTY_STRING = '';
-const SUPER_L = 'Super_L';
-const SUPER_R = 'Super_R';
-const HOT_KEY = { // See: org.gnome.shell.extensions.arc-menu.menu-hotkey
+var EMPTY_STRING = '';
+var SUPER_L = 'Super_L';
+var SUPER_R = 'Super_R';
+var HOT_KEY = { // See: org.gnome.shell.extensions.arc-menu.menu-hotkey
     Undefined: 0,
     Super_L: 1,
     Super_R: 2,
@@ -32,36 +32,36 @@ const HOT_KEY = { // See: org.gnome.shell.extensions.arc-menu.menu-hotkey
     1: SUPER_L,
     2: SUPER_R
 };
-const MENU_POSITION = { // See: org.gnome.shell.extensions.arc-menu.menu-position
+var MENU_POSITION = { // See: org.gnome.shell.extensions.arc-menu.menu-position
     Left: 0,
     Center: 1,
     Right: 2
 };
-const MENU_APPEARANCE = { // See: org.gnome.shell.extensions.arc-menu.menu-button-icon
+var MENU_APPEARANCE = { // See: org.gnome.shell.extensions.arc-menu.menu-button-icon
     Icon: 0,
     Text: 1,
     Icon_Text: 2,
     Text_Icon: 3
 };
-const MENU_BUTTON_TEXT = { // See: org.gnome.shell.extensions.arc-menu.menu-button-text
+var MENU_BUTTON_TEXT = { // See: org.gnome.shell.extensions.arc-menu.menu-button-text
     System: 0,
     Custom: 1
 };
-const MENU_BUTTON_ICON = { // See: org.gnome.shell.extensions.arc-menu.menu-button-icon
+var MENU_BUTTON_ICON = { // See: org.gnome.shell.extensions.arc-menu.menu-button-icon
     Arc_Menu: 0,
     System: 1,
     Custom: 2
 };
-const MENU_ICON_PATH = {
+var MENU_ICON_PATH = {
     Arc_Menu: '/media/arc-menu-symbolic.svg'
 };
-const ICON_SIZES = [ 16, 24, 32, 40, 48 ];
-const DEFAULT_ICON_SIZE = 22;
-const ARC_MENU_LOGO = {
+var ICON_SIZES = [ 16, 24, 32, 40, 48 ];
+var DEFAULT_ICON_SIZE = 22;
+var ARC_MENU_LOGO = {
     Path: '/media/logo.png',
     Size: [216, 229] // width, height
 };
-const GNU_SOFTWARE = '<span size="small">' +
+var GNU_SOFTWARE = '<span size="small">' +
     'This program comes with absolutely no warranty.\n' +
     'See the <a href="https://gnu.org/licenses/old-licenses/gpl-2.0.html">' +
 	'GNU General Public License, version 2 or later</a> for details.' +

--- a/controller.js
+++ b/controller.js
@@ -38,7 +38,7 @@ const _ = Gettext.gettext;
  * The Menu Settings Controller class is responsible for changing and handling
  * the settings changes of the Arc Menu.
  */
- const MenuSettingsController = new Lang.Class({
+ var MenuSettingsController = new Lang.Class({
     Name: 'ArcMenu.MenuSettingsController',
 
     _init: function(settings, menuButton) {

--- a/helper.js
+++ b/helper.js
@@ -38,7 +38,7 @@ const WM_KEYBINDINGS_SCHEMA = 'org.gnome.desktop.wm.keybindings';
  * The Menu HotKeybinder class helps us to bind and unbind a menu hotkey
  * to the Arc Menu. Currently, valid hotkeys are Super_L and Super_R.
  */
-const MenuHotKeybinder = new Lang.Class({
+var MenuHotKeybinder = new Lang.Class({
     Name: 'ArcMenu.MenuHotKeybinder',
 
     _init: function(menuToggler) {
@@ -115,7 +115,7 @@ const MenuHotKeybinder = new Lang.Class({
  * The Keybinding Manager class allows us to bind and unbind keybindings
  * to a keybinding handler.
  */
-const KeybindingManager = new Lang.Class({
+var KeybindingManager = new Lang.Class({
     Name: 'ArcMenu.KeybindingManager',
 
     _init: function(settings) {
@@ -180,7 +180,7 @@ const KeybindingManager = new Lang.Class({
  * The Hot Corner Manager class allows us to disable and enable
  * the gnome-shell hot corners.
  */
-const HotCornerManager = new Lang.Class({
+var HotCornerManager = new Lang.Class({
     Name: 'ArcMenu.HotCornerManager',
 
     _init: function(settings) {

--- a/logger.js
+++ b/logger.js
@@ -21,7 +21,7 @@
 const Lang = imports.lang;
 
 // Logging levels.
-const Level = {
+var Level = {
     Off: 0x00,
     Log: 0x01,
     Debug: 0x02,
@@ -33,7 +33,7 @@ const Level = {
 /**
  * A basic Logger class that supports multiple logging levels.
  */
-const Logger = new Lang.Class({
+var Logger = new Lang.Class({
     Name: 'ArcMenu.Logger',
 
     _init: function(params) {
@@ -60,5 +60,5 @@ const Logger = new Lang.Class({
     }
 });
 
-const logger = new Logger({ level: Level.All });
+var logger = new Logger({ level: Level.All });
 

--- a/menu.js
+++ b/menu.js
@@ -131,7 +131,7 @@ const ActivitiesMenuItem = new Lang.Class({
         this.actor.add_child(this._icon);
         let label = new St.Label({ text: _("Activities Overview"), y_expand: true,
                                       y_align: Clutter.ActorAlign.CENTER });
-        this.actor.add_child(label, { expand: true });
+        this.actor.add_child(label);
     },
 
     // Activate the menu item (Open activities overview)
@@ -264,7 +264,7 @@ const BackMenuItem = new Lang.Class({
         this.actor.add_child(this._icon);
         let backLabel = new St.Label({ text: _("Back"), y_expand: true,
                                       y_align: Clutter.ActorAlign.CENTER });
-        this.actor.add_child(backLabel, { expand: true });
+        this.actor.add_child(backLabel);
     },
 
     // Activate the button (go back to category view)
@@ -291,7 +291,7 @@ const ShortcutMenuItem = new Lang.Class({
         this.actor.add_child(this._icon);
         let label = new St.Label({ text: name, y_expand: true,
                                       y_align: Clutter.ActorAlign.CENTER });
-        this.actor.add_child(label, { expand: true });
+        this.actor.add_child(label);
     },
 
     // Activate the menu item (Launch the shortcut)
@@ -318,7 +318,7 @@ const UserMenuItem = new Lang.Class({
         this.actor.add_child(this._userIcon);
         this._userLabel = new St.Label({ text: username, y_expand: true,
                                       y_align: Clutter.ActorAlign.CENTER });
-        this.actor.add_child(this._userLabel, { expand: true });
+        this.actor.add_child(this._userLabel);
         this._userLoadedId = this._user.connect('notify::is_loaded', Lang.bind(this, this._onUserChanged));
         this._userChangedId = this._user.connect('changed', Lang.bind(this, this._onUserChanged));
         this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
@@ -374,7 +374,7 @@ const ApplicationMenuItem = new Lang.Class({
 
         let appLabel = new St.Label({ text: app.get_name(), y_expand: true,
                                       y_align: Clutter.ActorAlign.CENTER });
-        this.actor.add_child(appLabel, { expand: true });
+        this.actor.add_child(appLabel);
         this.actor.label_actor = appLabel;
 
         let textureCache = St.TextureCache.get_default();
@@ -470,7 +470,7 @@ const CategoryMenuItem = new Lang.Class({
         this.actor.add_child(this._icon);
         let categoryLabel = new St.Label({ text: name, y_expand: true,
                                       y_align: Clutter.ActorAlign.CENTER });
-        this.actor.add_child(categoryLabel, { expand: true });
+        this.actor.add_child(categoryLabel);
         this.actor.label_actor = categoryLabel;
     },
 
@@ -546,7 +546,7 @@ const PlaceMenuItem = new Lang.Class({
 	    this.actor.add_child(this._icon);
         this._label = new St.Label({ text: info.name, y_expand: true,
                                       y_align: Clutter.ActorAlign.CENTER });
-        this.actor.add_child(this._label, { expand: true });
+        this.actor.add_child(this._label);
         this._changedId = this._info.connect('changed',
                                        Lang.bind(this, this._propertiesChanged));
     },
@@ -684,7 +684,7 @@ const MenuButtonWidget = new Lang.Class({
 
 
 // Application Menu Button class (most of the menu logic is here)
-const ApplicationsButton = new Lang.Class({
+var ApplicationsButton = new Lang.Class({
     Name: 'ApplicationsButton',
     Extends: PanelMenu.Button,
 


### PR DESCRIPTION
I tested Arc Menu on Ubuntu 17.10 and discovered the following JS warnings (see #141):
 * Warning 1: Too many arguments to method Clutter.Actor.add_child: expected 1, got 2
 * Warning 2: That property was defined with 'let' or 'const' inside the module.

It seems that Clutter.Actor.add_child() only expects a single argument, namely a child actor [2].

The fix for warning 1 is pretty simple, we just remove the extra argument.
And to fix warning 2, we simply use the keyword 'var' to export classes and constants to other modules.

Thus, some 'const' keywords are replaced with a 'var' keyword in the following files:
 * controller.js
 * helper.js
 * menu.js
 * constants.js
 * logger.js

[1] http://paste.debian.net/983968
[2] https://developer.gnome.org/clutter/stable/ClutterActor.html#clutter-actor-add-child