### PR TITLE
Prevent double destruction of the menu sections when disabling the extension

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -710,9 +710,6 @@ var ApplicationsButton = new Lang.Class({
 
     // Destroy (deactivate) the menu
     destroy: function() {
-        this.menu.actor.get_children().forEach(function(c) {
-            c.destroy();
-        });
         if (this._searchBoxClearedId > 0) {
             this.searchBox.disconnect(this._searchBoxClearedId);
             this._searchBoxClearedId = 0;


### PR DESCRIPTION
Hi LinxGem33, this is a small fix for #215. Seems like the menu sections are destroyed by the parent (PopupMenuBase in gnome-shell/ui/popupMenu.js), so no need to destroy them explicitly. Cheers!