### PR TITLE
Disconnect height notification signal on extension disable

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -148,7 +148,7 @@ var ApplicationsButton = new Lang.Class({
                 this.reloadFlag = true;
             }
         }));
-        Main.panel.actor.connect('notify::height', Lang.bind(this, function() {
+        this._notifyHeightId = Main.panel.actor.connect('notify::height', Lang.bind(this, function() {
             this._redisplay();
         }));
     },
@@ -175,6 +175,7 @@ var ApplicationsButton = new Lang.Class({
     _onDestroy: function() {
         Main.overview.disconnect(this._showingId);
         Main.overview.disconnect(this._hidingId);
+        Main.panel.actor.disconnect(this._notifyHeightId);
         appSys.disconnect(this._installedChangedId);
     },
 


### PR DESCRIPTION
Hi LinxGem33, I could reproduce the warnings as mentioned in #209, although my system doesn't freeze. Seems like, coming back from the lock screen, dash to panel is enabled before arc-menu and sends a height notification that arc-menu listens to (while not yet enabled), and it causes the issue. Disconnecting the signal on disable fixes it on my end. Cheers!