### PR TITLE
Made default user avatar image symbolic

### DIFF
--- a/menuWidgets.js
+++ b/menuWidgets.js
@@ -309,7 +309,7 @@ var UserMenuItem = new Lang.Class({
             if (this._userIcon) {
                 let iconFileName = this._user.get_icon_file();
                 let iconFile = Gio.file_new_for_path(iconFileName);
-                setIconAsync(this._userIcon, iconFile, 'avatar-default');
+                setIconAsync(this._userIcon, iconFile, 'avatar-default-symbolic');
             }
         }
     },


### PR DESCRIPTION
Changing the default avatar image to be symbolic makes the icon more consistent with the rest of the right pane of the menu.