### PR TITLE
Add terminal shortcut to menu.js

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -468,7 +468,10 @@ var ApplicationsButton = new Lang.Class({
                     command: "gnome-tweak-tool" },
                 {   label: _("Tweaks"), // Tweak Tool is called Tweaks in GNOME 3.26
                     symbolic: "gnome-tweak-tool-symbolic",
-                    command: "gnome-tweaks" }
+                    command: "gnome-tweaks" },
+		{   label: _("Terminal"),
+                    symbolic: "gnome-terminal-symbolic",
+                    command: "gnome-terminal" }
             ];
             shortcuts.forEach(Lang.bind(this, function(shortcut) {
                 if (GLib.find_program_in_path(shortcut.command)) {


### PR DESCRIPTION
adds a shortcut to the gnome terminal on the menu